### PR TITLE
Plugin System Hardening Sprint — 87 findings, 10 batches

### DIFF
--- a/.dev-state/plugin-hardening-grill.md
+++ b/.dev-state/plugin-hardening-grill.md
@@ -1,0 +1,136 @@
+# Plugin Hardening Sprint — Grill Decisions
+
+> **Date**: 2026-04-13
+> **Decisions**: 43
+> **Status**: COMPLETE — all branches resolved, all 87 findings covered
+
+## Decisions
+
+| # | Decision | Findings | Rationale |
+|---|----------|----------|-----------|
+| 1 | Fix all 87 findings (hardening sprint completo) | All | Sistema em producao, rampando volume |
+| 2 | Batches sequenciais por camada, commits atomicos | Exec | server.ts tocado por ~30 findings, paralelo causa conflito |
+| 3 | DB/Schema first, revalidacao cascata | Ordering | Schema changes afetam camadas superiores |
+| 4 | Recreate tables, DB limpo, sem migracao | DB | Apenas dados de teste internos, nao ha dados de producao |
+| 5 | Contrato interno, nada eh breaking | Risk | Dispatch eh componente interno, controlamos ambos os lados |
+| 6 | handle_result idempotente, P5 seguro | P5 | DispatchCallbackHandler faz lookup + update idempotente |
+| 7 | Implementar `waiting_device` como status ativo | D1, R6 | Visibilidade quando devices offline, nao dead code |
+| 8 | TTL adaptativo, default 24h, baseado em device uptime | R6 | Sem TTL fixo, adapta ao padrao de retorno |
+| 9 | Recovery `sending`: 2x worst case = 300s (5min) | R1 | Per-op timeout 30s x 5 ops max = 150s, 2x = 300s |
+| 10 | State machine enforced: `updateStatus(id, from, to)` | D2 | Transicoes invalidas como queued→sent bloqueadas |
+| 11 | Novo callback type `interim_failure` (opcao C) | P5 | Visibilidade de falha ADB antes do fallback WAHA |
+| 12 | Proteger `/metrics` com API key | S14 | Phone numbers em labels, endpoint nao deve ser publico |
+| 13 | Webhook URL allowlist de dominios via env var | S6 | SSRF protection, suffix match |
+| 14 | Wire `markSendActive`, SIGTERM espera 30s + flush | R5 | Drain mecanismo existe mas nunca wired |
+| 15 | Backoff exponencial tick: 5s→10s→20s→40s→60s cap | R7 | Evita busy-loop quando todos senders capped |
+| 16 | Failed callbacks: manter para auditoria, WHERE attempts<10 | R8, DB7 | Dados para compliance, scan otimizado |
+| 17 | patientId/templateId merged no context JSON | P1 | Fire-and-forget mas auditavel via context field |
+| 18 | Dedup window unificada 30s | P7 | Rate limiter 15-45s entre msgs garante sem false-positive |
+| 19 | Sem purge messages/events. Indexes para performance | DB6 | Compliance: audit trail completo |
+| 20 | Wire `onError` com log + metrica Prometheus | A3 | Plugin handler errors silenciados hoje |
+| 21 | Backoff interval 5s base confirmado | R7 | Worker tick eh 5s (nao 2s como estimado) |
+| 22 | Allowlist: suffix match, HTTPS-only prod, obrigatorio | S6 | `DISPATCH_WEBHOOK_ALLOWED_DOMAINS=debt.com.br` |
+| 23 | 4+ novas metricas + atualizar dashboards Grafana | A4,A8,A10 | callbacks_total, plugin_errors, queue_depth_by_plugin, dedup_miss |
+| 24 | Python handler first (`interim_failure`+`expired`), Dispatch second | Cross-repo | Deploy order: Python → Dispatch |
+| 25 | Fail-closed auth: timingSafeEqual, all verbs, strip secrets | S1-S5 | Timing oracle + auth bypass + credential leak |
+| 26 | Input schema: bodyLimit 1MB, text 4096, E.164 regex, batch 500, context 64KB, path allowlist, /healthz degradado | S7-S13 | DoS protection + input validation |
+| 27 | AbortSignal.timeout(10s) todo outbound HTTP, configuravel via env | S15, R11 | Fetch sem timeout trava event loop |
+| 28 | Phone numbers mantidos em labels Prometheus (endpoint protegido) | S14 | Operador precisa correlacionar sender com numero real |
+| 29 | Batch partial-failure per-item. ON CONFLICT DO NOTHING. Blacklist skip | P8, R4 | Idempotencia + robustez de batch |
+| 30 | Gerar dispatch_message_id no send. WAHA ID no AckCallback | P4 | Callback imediato com ID, WAHA ID async |
+| 31 | maxRetries = total attempts. Fix off-by-one | P11 | `attempts >= maxRetries` nao `attempts + 1 < maxRetries` |
+| 32 | Fixes fluxo: queued event, JSON.parse guard, fallback fields, waha query scope, sender resolution | P2,P3,P6,P9,P10 | 5 fixes diretos sem trade-off |
+| 33 | Plugin lifecycle: error log, destroyAll safe, registry source of truth, upsert creds, webhook obrigatorio | R2,R3,R9,R10,R12 | 5 fixes lifecycle |
+| 34 | Auditabilidade: stale lock log, requeue trace, callback body, retry error, labels, pino, timeline, dedup miss | A1-A13 | 9 fixes observabilidade |
+| 35 | Data integrity: attempts real, sent_at column, atomic transaction, FK, typed enum | D3-D8 | 5 fixes integridade |
+| 36 | DB hardening: busy_timeout 5000, branch query, WAL checkpoint 400, CHECK priority | DB1,DB4,DB5,DB8 | 4 fixes DB |
+| 37 | Code quality: timer leak, paused senders, pluginName validation, non-destructive metadata | Q1-Q4 | 4 fixes qualidade |
+| 38 | Testes junto com cada batch. E2E in-process prioridade #1 | T1-T14 | Testes nao sao batch separado |
+| 39 | Sender phone normalizacao digits-only no receptor (Postel's Law) | Contract | Oralsin envia E.164 com +, Dispatch normaliza |
+| 40 | 503 retryable com backoff inline [0, 1s, 2s, 4s] | Contract | Race condition resolve em <50ms, 503 era non-retryable |
+| 41 | `interim_failure` com erro real + `failed_sender` + `next_sender` | Contract | Visibilidade completa da cadeia de fallback |
+| 42 | `expired` callback + DeferredNotification fallback | Contract | TTL expira → callback imediato, detect_stuck como safety net |
+| 43 | `fallback_reason.original_error` real (nao hardcoded) | Contract | Redundancia intencional com interim_failure |
+
+## Cross-Repo Dependencies
+
+### Python/Oralsin (BLOQUEANTE — deploy ANTES do Dispatch)
+
+1. `dispatch_callback_view.py`: routing para `interim_failure` e `expired`
+2. `DispatchCallbackHandler.handle_interim_failure()`:
+   - Localizar ContactHistory por idempotency_key
+   - NAO alterar outcome (manter PENDING)
+   - Appendar ao outcome_details: timestamp, error code, error message, failed provider
+   - Metrica: `dispatch_interim_failure_total{error_code}`
+   - Alerta Telegram se `error.code == "ban_detected"`
+3. `DispatchCallbackHandler.handle_expired()`:
+   - ContactHistory: outcome=ERROR, outcome_reason="ttl_expired"
+   - Schedule: PROCESSING → REJECTED
+   - Avaliar fallback WAHA: DISPATCH_FALLBACK_TO_WAHA + janela horario comercial
+   - Se OK: DeferredNotification reason="dispatch_ttl_expired"
+   - Alerta Telegram: WARN se 1 schedule, CRIT se >5 expirados/hora
+
+### Contract Summary
+
+#### Callback Types (5 total)
+
+| Type | Event Field | When | Oralsin Action |
+|------|------------|------|----------------|
+| result | null | Send complete (success/fail) | Update ContactHistory outcome |
+| ack_update | "ack_update" | WAHA delivery/read receipt | Update delivered_at/read_at |
+| patient_response | "patient_response" | Patient replies | Store in ContactHistory |
+| interim_failure | "interim_failure" | ADB failed, before fallback | Log attempt, alert on ban |
+| expired | "expired" | TTL expired, no device available | REJECTED + fallback WAHA |
+
+#### `interim_failure` Payload
+```json
+{
+  "event": "interim_failure",
+  "idempotency_key": "sched-123-whatsapp",
+  "correlation_id": "notif-abc",
+  "status": "interim_failed",
+  "error": {
+    "code": "ban_detected|device_offline|typing_timeout|...",
+    "message": "Human-readable detail",
+    "retryable": true
+  },
+  "failed_sender": { "phone": "+554396835095", "session": "oralsin_2_1", "pair": "oralsin-2-1" },
+  "next_sender": { "phone": "+554396837813", "session": "oralsin_2_2", "pair": "oralsin-2-2", "role": "overflow" },
+  "attempt": 1,
+  "context": { "schedule_id": 123, "clinic_id": 5, "..." }
+}
+```
+
+#### `expired` Payload
+```json
+{
+  "event": "expired",
+  "idempotency_key": "sched-123-whatsapp",
+  "correlation_id": "notif-abc",
+  "status": "expired",
+  "error": {
+    "code": "ttl_expired",
+    "message": "No device available for 24h, message expired",
+    "retryable": false
+  },
+  "context": { "schedule_id": 123, "clinic_id": 5, "..." }
+}
+```
+
+#### `fallback_reason` (in result callback when used_fallback=true)
+```json
+{
+  "original_error": "ban_detected",
+  "original_message": "WhatsApp session banned on device oralsin-2-1",
+  "original_session": "oralsin_2_1",
+  "quarantined": true
+}
+```
+
+## Phone Format Contract
+
+| Field | Oralsin Sends | Dispatch Stores | Dispatch Lookup |
+|-------|--------------|-----------------|-----------------|
+| patient.phone | "5543991938235" (13 digits, no +) | verbatim in messages.to | normalized to digits in send-engine |
+| senders[].phone | "+554396837945" (E.164 with +) | digits-only in sender_mapping | digits-only (Postel's Law) |
+| callback.delivery.sender_phone | — | messages.sender_number | from resolved mapping |

--- a/.dev-state/progress.md
+++ b/.dev-state/progress.md
@@ -1,9 +1,11 @@
 # Development Progress — DEBT ADB Framework
 
-> **Last updated**: 2026-04-10T18:40:00-03:00
-> **Current phase**: ANTI-FINGERPRINT HARDENING COMPLETE + CONTACT AGING E2E VALIDATED
-> **Next action**: Monitor production DataPrepWorkflow (amanhã 09:00 BRT) for first real contact aging batch
-> **Plan**: `docs/superpowers/plans/2026-04-10-anti-fingerprint-hardening.md` — 6/8 tasks done (P1-B UHID + UI deferred)
+> **Last updated**: 2026-04-13T22:00:00-03:00
+> **Current phase**: PLUGIN HARDENING SPRINT — IN_PROGRESS (Batch 0/10)
+> **Next action**: Execute `plans/plugin-hardening-sprint.md` Batch 1 (DB Schema)
+> **Plan**: `plans/plugin-hardening-sprint.md` — 10 batches, 87 findings, 43 grill decisions
+> **Grill**: `.dev-state/plugin-hardening-grill.md` — 43 decisions, all resolved
+> **Cross-repo**: Python/Oralsin side DONE (interim_failure + expired handlers deployed)
 > **Tech docs**: `docs/tech/` — schema, API ref, UI patterns, conventions
 
 ## Phase Status

--- a/.dev-state/progress.md
+++ b/.dev-state/progress.md
@@ -1,11 +1,14 @@
 # Development Progress — DEBT ADB Framework
 
-> **Last updated**: 2026-04-13T22:00:00-03:00
-> **Current phase**: PLUGIN HARDENING SPRINT — IN_PROGRESS (Batch 0/10)
-> **Next action**: Execute `plans/plugin-hardening-sprint.md` Batch 1 (DB Schema)
+> **Last updated**: 2026-04-13T23:30:00-03:00
+> **Current phase**: PLUGIN HARDENING SPRINT — COMPLETE (Batch 10/10)
+> **Next action**: Deploy Python side (interim_failure + expired handlers), then Dispatch
 > **Plan**: `plans/plugin-hardening-sprint.md` — 10 batches, 87 findings, 43 grill decisions
 > **Grill**: `.dev-state/plugin-hardening-grill.md` — 43 decisions, all resolved
 > **Cross-repo**: Python/Oralsin side DONE (interim_failure + expired handlers deployed)
+> **Contract**: `docs/contract-dispatch-oralsin.md` — 5 callback types, HMAC, phone normalization
+> **Branch**: `hardening/plugin-system` — 10 commits, ready for PR
+> **Tests**: 784 passing (35 new tests in this sprint)
 > **Tech docs**: `docs/tech/` — schema, API ref, UI patterns, conventions
 
 ## Phase Status

--- a/docs/contract-dispatch-oralsin.md
+++ b/docs/contract-dispatch-oralsin.md
@@ -1,0 +1,164 @@
+# Dispatch ↔ Oralsin Contract
+
+> **Version**: 2.0 (Hardening Sprint)
+> **Date**: 2026-04-13
+> **Status**: Active — Python side must deploy `interim_failure`/`expired` handlers before Dispatch
+
+## Enqueue Request
+
+`POST /api/v1/plugins/oralsin/enqueue`
+
+**Headers**:
+- `X-API-Key: <PLUGIN_ORALSIN_API_KEY>` (required)
+- `Content-Type: application/json`
+
+**Body**: Single item or array (max 500 items)
+
+```json
+{
+  "idempotency_key": "sched-123-whatsapp",
+  "correlation_id": "notif-abc",
+  "patient": {
+    "phone": "5543991938235",
+    "name": "Maria Silva",
+    "patient_id": "uuid-1"
+  },
+  "message": {
+    "text": "Lembrete de consulta...",
+    "template_id": "overdue_reminder_v2"
+  },
+  "senders": [
+    { "phone": "+554396837945", "session": "oralsin_1_4", "pair": "oralsin-1-4", "role": "primary" },
+    { "phone": "+554396837813", "session": "oralsin_2_2", "pair": "oralsin-2-2", "role": "overflow" }
+  ],
+  "context": { "schedule_id": 123, "clinic_id": 5 },
+  "send_options": { "max_retries": 3, "priority": "normal" }
+}
+```
+
+**Validation**:
+- `patient.phone`, `senders[].phone`: E.164 regex `/^\+?\d{10,15}$/`
+- `message.text`: max 4096 chars
+- Batch: max 500 items
+- `context`: max 64KB JSON
+- `send_options.priority`: `"normal"` | `"high"`
+- `send_options.max_retries`: 1-10
+
+**Phone Normalization** (Postel's Law):
+- `+554396837945` and `554396837945` resolve to same sender_mapping row
+- Dispatch normalizes to digits-only on receipt
+
+**Partial Failure**: Blacklisted/duplicate items are skipped per-item (no rollback).
+
+## Callback Types (5 total)
+
+All callbacks are `POST` to `PLUGIN_ORALSIN_WEBHOOK_URL` with:
+- `Content-Type: application/json`
+- `X-Dispatch-Signature: <HMAC-SHA256 of body>`
+
+### 1. `result` — Send complete
+
+```json
+{
+  "idempotency_key": "sched-123-whatsapp",
+  "correlation_id": "notif-abc",
+  "status": "sent",
+  "sent_at": "2026-04-13T15:00:00.123Z",
+  "delivery": {
+    "message_id": "waha-msg-id",
+    "provider": "adb",
+    "sender_phone": "554396837945",
+    "sender_session": "oralsin_1_4",
+    "pair_used": "oralsin-1-4",
+    "used_fallback": false,
+    "elapsed_ms": 12500,
+    "device_serial": "9b01005930533036340030832250ac",
+    "profile_id": 0,
+    "char_count": 142,
+    "contact_registered": true,
+    "screenshot_url": "/api/v1/messages/abc123/screenshot",
+    "dialogs_dismissed": 1,
+    "user_switched": false
+  },
+  "error": null,
+  "context": { "schedule_id": 123, "clinic_id": 5, "patient_id": "uuid-1", "template_id": "overdue_reminder_v2" }
+}
+```
+
+### 2. `ack_update` — Delivery/read receipt
+
+```json
+{
+  "idempotency_key": "sched-123-whatsapp",
+  "message_id": "waha-msg-id",
+  "event": "ack_update",
+  "ack": { "level": 3, "level_name": "read", "delivered_at": "...", "read_at": "..." }
+}
+```
+
+### 3. `patient_response` — Patient replies
+
+```json
+{
+  "idempotency_key": "sched-123-whatsapp",
+  "message_id": "waha-msg-id",
+  "event": "patient_response",
+  "response": { "body": "ok confirmado", "received_at": "...", "from_number": "5543991938235", "has_media": false }
+}
+```
+
+### 4. `interim_failure` — ADB failed, before fallback
+
+```json
+{
+  "event": "interim_failure",
+  "idempotency_key": "sched-123-whatsapp",
+  "correlation_id": "notif-abc",
+  "status": "interim_failed",
+  "error": { "code": "ban_detected", "message": "WhatsApp session banned", "retryable": true },
+  "failed_sender": { "phone": "+554396835095", "session": "oralsin_2_1", "pair": "oralsin-2-1" },
+  "next_sender": { "phone": "+554396837813", "session": "oralsin_2_2", "pair": "oralsin-2-2", "role": "overflow" },
+  "attempt": 1,
+  "context": { "schedule_id": 123, "clinic_id": 5 }
+}
+```
+
+### 5. `expired` — TTL expired
+
+```json
+{
+  "event": "expired",
+  "idempotency_key": "sched-123-whatsapp",
+  "correlation_id": "notif-abc",
+  "status": "expired",
+  "error": { "code": "ttl_expired", "message": "No device available for 24h", "retryable": false },
+  "context": { "schedule_id": 123, "clinic_id": 5 }
+}
+```
+
+## HMAC Verification
+
+```python
+import hmac, hashlib
+
+def verify_dispatch_signature(body_bytes: bytes, secret: str, signature: str) -> bool:
+    expected = hmac.new(secret.encode(), body_bytes, hashlib.sha256).hexdigest()
+    return hmac.compare_digest(expected, signature)
+```
+
+## 503 Retry Semantics
+
+Dispatch retries 503 responses with short backoff: [0, 1s, 2s, 4s].
+Other 5xx: standard backoff [0, 5s, 30s, 120s].
+4xx: non-retryable (breaks immediately).
+
+## `fallback_reason` (in result callback when `used_fallback=true`)
+
+```json
+{
+  "original_error": "ban_detected",
+  "original_message": "WhatsApp session banned on device oralsin-2-1",
+  "original_session": "oralsin_2_1",
+  "quarantined": true
+}
+```

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -9,3 +9,6 @@ scrape_configs:
       - targets: ["host.docker.internal:7890"]
         labels:
           instance: "dispatch-core"
+    # S13: /metrics now requires API key authentication
+    headers:
+      X-API-Key: "${DISPATCH_API_KEY}"

--- a/packages/core/src/api/api-auth.ts
+++ b/packages/core/src/api/api-auth.ts
@@ -3,7 +3,7 @@ import type { FastifyInstance } from 'fastify'
 
 const PUBLIC_ROUTES = [
   '/api/v1/health',
-  '/metrics',
+  // S13: /metrics removed — now requires API key (Decision #12)
 ]
 
 const PUBLIC_PREFIXES = [

--- a/packages/core/src/api/audit.test.ts
+++ b/packages/core/src/api/audit.test.ts
@@ -100,7 +100,9 @@ describe('AuditService', () => {
 
     it('filters by status', () => {
       const msg = queue.enqueue({ to: '5543991938235', body: 'Will be sent', idempotencyKey: 'ks1' })
-      queue.updateStatus(msg.id, 'sent')
+      queue.updateStatus(msg.id, 'queued', 'locked')
+      queue.updateStatus(msg.id, 'locked', 'sending')
+      queue.updateStatus(msg.id, 'sending', 'sent')
       queue.enqueue({ to: '5543991938235', body: 'Still queued', idempotencyKey: 'ks2' })
 
       const result = audit.listCombined({ status: 'sent' })
@@ -155,8 +157,9 @@ describe('AuditService', () => {
       const msg = queue.enqueue({ to: '5543991938235', body: 'Timeline test', idempotencyKey: 'kt1' })
 
       // Simulate status transitions
-      queue.updateStatus(msg.id, 'sending')
-      queue.updateStatus(msg.id, 'sent')
+      queue.updateStatus(msg.id, 'queued', 'locked')
+      queue.updateStatus(msg.id, 'locked', 'sending')
+      queue.updateStatus(msg.id, 'sending', 'sent')
 
       // Add a WAHA capture for correlation
       history.insert({

--- a/packages/core/src/api/metrics.test.ts
+++ b/packages/core/src/api/metrics.test.ts
@@ -32,7 +32,9 @@ describe('Metrics', () => {
     })
 
     if (overrides.status && overrides.status !== 'queued') {
-      queue.updateStatus(msg.id, overrides.status as 'sent' | 'failed')
+      queue.updateStatus(msg.id, 'queued', 'locked')
+      queue.updateStatus(msg.id, 'locked', 'sending')
+      queue.updateStatus(msg.id, 'sending', overrides.status as 'sent' | 'failed')
     }
 
     // Allow manual timestamp overrides for testing

--- a/packages/core/src/api/plugin-oralsin.test.ts
+++ b/packages/core/src/api/plugin-oralsin.test.ts
@@ -57,7 +57,9 @@ describe('Oralsin Plugin Monitoring API', () => {
     })
 
     if (overrides.status && overrides.status !== 'queued') {
-      queue.updateStatus(msg.id, overrides.status as 'sent' | 'failed')
+      queue.updateStatus(msg.id, 'queued', 'locked')
+      queue.updateStatus(msg.id, 'locked', 'sending')
+      queue.updateStatus(msg.id, 'sending', overrides.status as 'sent' | 'failed')
     }
 
     if (overrides.fallbackUsed !== undefined || overrides.fallbackProvider !== undefined) {

--- a/packages/core/src/config/config-schema.test.ts
+++ b/packages/core/src/config/config-schema.test.ts
@@ -137,6 +137,10 @@ describe('parseConfig', () => {
     const config = parseConfig({
       ...minimalEnv,
       DISPATCH_PLUGINS: 'oralsin, custom-plugin',
+      PLUGIN_ORALSIN_API_KEY: 'test-key',
+      PLUGIN_ORALSIN_HMAC_SECRET: 'test-secret',
+      PLUGIN_ORALSIN_WEBHOOK_URL: 'https://test.debt.com.br/webhook',
+      DISPATCH_WEBHOOK_ALLOWED_DOMAINS: 'debt.com.br',
     })
     expect(config.plugins).toEqual(['oralsin', 'custom-plugin'])
   })

--- a/packages/core/src/config/config-schema.ts
+++ b/packages/core/src/config/config-schema.ts
@@ -56,6 +56,12 @@ const envSchema = z
     // Plugins
     DISPATCH_PLUGINS: z.string().default(''),
     PLUGIN_ORALSIN_WEBHOOK_URL: z.string().optional(),
+    PLUGIN_ORALSIN_API_KEY: z.string().optional(),
+    PLUGIN_ORALSIN_HMAC_SECRET: z.string().optional(),
+
+    // Security
+    DISPATCH_WEBHOOK_ALLOWED_DOMAINS: z.string().optional(),
+    DISPATCH_HTTP_TIMEOUT_MS: z.coerce.number().int().min(1000).max(60000).default(10000),
 
     // Retention
     MESSAGE_HISTORY_RETENTION_DAYS: z.coerce.number().default(90),
@@ -68,6 +74,23 @@ const envSchema = z
         message: 'DISPATCH_API_KEY is required in production and development environments',
         path: ['DISPATCH_API_KEY'],
       })
+    }
+
+    // S3/R12/Decision #22: Conditional required fields when plugins enabled
+    const plugins = data.DISPATCH_PLUGINS?.split(',').map(s => s.trim()).filter(Boolean) ?? []
+    if (plugins.includes('oralsin')) {
+      if (!data.PLUGIN_ORALSIN_API_KEY) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'PLUGIN_ORALSIN_API_KEY required when oralsin plugin enabled', path: ['PLUGIN_ORALSIN_API_KEY'] })
+      }
+      if (!data.PLUGIN_ORALSIN_HMAC_SECRET) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'PLUGIN_ORALSIN_HMAC_SECRET required when oralsin plugin enabled', path: ['PLUGIN_ORALSIN_HMAC_SECRET'] })
+      }
+      if (!data.PLUGIN_ORALSIN_WEBHOOK_URL) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'PLUGIN_ORALSIN_WEBHOOK_URL required when oralsin plugin enabled', path: ['PLUGIN_ORALSIN_WEBHOOK_URL'] })
+      }
+    }
+    if (plugins.length > 0 && !data.DISPATCH_WEBHOOK_ALLOWED_DOMAINS) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'DISPATCH_WEBHOOK_ALLOWED_DOMAINS required when plugins enabled', path: ['DISPATCH_WEBHOOK_ALLOWED_DOMAINS'] })
     }
   })
 
@@ -119,6 +142,10 @@ export interface DispatchConfig {
   }
   plugins: string[]
   pluginOralsinWebhookUrl?: string
+  pluginOralsinApiKey?: string
+  pluginOralsinHmacSecret?: string
+  webhookAllowedDomains?: string
+  httpTimeoutMs: number
   messageHistoryRetentionDays: number
 }
 
@@ -179,6 +206,10 @@ export function parseConfig(env: Record<string, string | undefined>): DispatchCo
       ? parsed.DISPATCH_PLUGINS.split(',').map((s) => s.trim()).filter(Boolean)
       : [],
     pluginOralsinWebhookUrl: parsed.PLUGIN_ORALSIN_WEBHOOK_URL,
+    pluginOralsinApiKey: parsed.PLUGIN_ORALSIN_API_KEY,
+    pluginOralsinHmacSecret: parsed.PLUGIN_ORALSIN_HMAC_SECRET,
+    webhookAllowedDomains: parsed.DISPATCH_WEBHOOK_ALLOWED_DOMAINS,
+    httpTimeoutMs: parsed.DISPATCH_HTTP_TIMEOUT_MS,
     messageHistoryRetentionDays: parsed.MESSAGE_HISTORY_RETENTION_DAYS,
   }
 }

--- a/packages/core/src/config/metrics.ts
+++ b/packages/core/src/config/metrics.ts
@@ -33,6 +33,27 @@ export const quarantineEventsTotal = new Counter({
   registers: [metricsRegistry],
 })
 
+// Decision #23: Plugin-level metrics
+export const callbacksTotal = new Counter({
+  name: 'dispatch_callbacks_total',
+  help: 'Total callbacks sent',
+  labelNames: ['plugin', 'type', 'status'] as const,
+  registers: [metricsRegistry],
+})
+
+export const pluginErrorsTotal = new Counter({
+  name: 'dispatch_plugin_errors_total',
+  help: 'Plugin handler errors',
+  labelNames: ['plugin', 'event'] as const,
+  registers: [metricsRegistry],
+})
+
+export const wahaDedupmissTotal = new Counter({
+  name: 'dispatch_waha_dedup_miss_total',
+  help: 'WAHA dedup window misses',
+  registers: [metricsRegistry],
+})
+
 // ── Histograms (distribution) ──
 
 export const sendDurationSeconds = new Histogram({
@@ -56,6 +77,13 @@ export const interMessageDelaySeconds = new Histogram({
 export const queueDepth = new Gauge({
   name: 'dispatch_queue_depth',
   help: 'Current number of messages in queue (pending + processing)',
+  registers: [metricsRegistry],
+})
+
+export const queueDepthByPlugin = new Gauge({
+  name: 'dispatch_queue_depth_by_plugin',
+  help: 'Queue depth per plugin',
+  labelNames: ['plugin', 'status'] as const,
   registers: [metricsRegistry],
 })
 

--- a/packages/core/src/engine/receipt-tracker.ts
+++ b/packages/core/src/engine/receipt-tracker.ts
@@ -57,7 +57,7 @@ export class ReceiptTracker {
         waha_message_id TEXT,
         delivered_emitted INTEGER NOT NULL DEFAULT 0,
         read_emitted INTEGER NOT NULL DEFAULT 0,
-        created_at TEXT NOT NULL DEFAULT (datetime('now'))
+        created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
       );
       CREATE INDEX IF NOT EXISTS idx_pending_corr_lookup
         ON pending_correlations(to_number_normalized, sender_number_normalized, sent_at);

--- a/packages/core/src/engine/send-engine.test.ts
+++ b/packages/core/src/engine/send-engine.test.ts
@@ -100,13 +100,19 @@ describe('SendEngine', () => {
     vi.spyOn(engine as any, 'delay').mockResolvedValue(undefined)
   })
 
-  /** Enqueue and return the real DB message */
+  /** Enqueue and return the real DB message (status = 'queued') */
   const enqueueMsg = (key = 'key-1') =>
     queue.enqueue({ to: '5543991938235', body: 'Hi', idempotencyKey: key, senderNumber: '5543996835100' })
+
+  /** Lock a queued message so send() can transition locked → sending */
+  const lockMsg = (id: string) => {
+    db.prepare("UPDATE messages SET status = 'locked', locked_by = 'test-device' WHERE id = ?").run(id)
+  }
 
   describe('send() — user switching at batch level', () => {
     it('does NOT call am switch-user (handled by worker loop)', async () => {
       const msg = enqueueMsg()
+      lockMsg(msg.id)
       stubShellForSend(mockAdb)
 
       await engine.send(msg, 'device-1')
@@ -118,6 +124,7 @@ describe('SendEngine', () => {
 
     it('does NOT include --user flag in am start (user already switched)', async () => {
       const msg = enqueueMsg()
+      lockMsg(msg.id)
       stubShellForSend(mockAdb)
 
       await engine.send(msg, 'device-1')
@@ -130,6 +137,7 @@ describe('SendEngine', () => {
 
     it('force-stops WhatsApp in ensureCleanState', async () => {
       const msg = enqueueMsg('clean-1')
+      lockMsg(msg.id)
       stubShellForSend(mockAdb)
 
       await engine.send(msg, 'device-1')
@@ -140,6 +148,7 @@ describe('SendEngine', () => {
 
     it('emits message:sending and message:sent events', async () => {
       const msg = enqueueMsg()
+      lockMsg(msg.id)
       stubShellForSend(mockAdb)
 
       const events: string[] = []
@@ -153,6 +162,7 @@ describe('SendEngine', () => {
 
     it('returns screenshot buffer, duration, and audit metadata', async () => {
       const msg = enqueueMsg()
+      lockMsg(msg.id)
       stubShellForSend(mockAdb)
 
       const result = await engine.send(msg, 'device-1')
@@ -167,6 +177,7 @@ describe('SendEngine', () => {
   describe('dialog detection', () => {
     it('dismisses "Enviar para" chooser and taps WhatsApp + Sempre', async () => {
       const msg = enqueueMsg('dialog-1')
+      lockMsg(msg.id)
       const shellMock = mockAdb.shell as ReturnType<typeof vi.fn>
 
       let dumpCount = 0
@@ -204,6 +215,7 @@ describe('SendEngine', () => {
 
     it('dismisses "Continuar" button', async () => {
       const msg = enqueueMsg('dialog-2')
+      lockMsg(msg.id)
       const shellMock = mockAdb.shell as ReturnType<typeof vi.fn>
 
       let dumpCount = 0
@@ -235,6 +247,7 @@ describe('SendEngine', () => {
 
     it('dismisses "Permitir" notification permission', async () => {
       const msg = enqueueMsg('dialog-3')
+      lockMsg(msg.id)
       const shellMock = mockAdb.shell as ReturnType<typeof vi.fn>
 
       let dumpCount = 0
@@ -265,6 +278,7 @@ describe('SendEngine', () => {
 
     it('throws transient error when chat input never appears', async () => {
       const msg = enqueueMsg('dialog-4')
+      lockMsg(msg.id)
       const shellMock = mockAdb.shell as ReturnType<typeof vi.fn>
 
       shellMock.mockImplementation(async (_serial: string, cmd: string) => {
@@ -313,12 +327,14 @@ describe('SendEngine', () => {
 
     it('allows valid com.whatsapp package', async () => {
       const msg = enqueueMsg('guard-6')
+      lockMsg(msg.id)
       stubShellForSend(mockAdb)
       await expect(engine.send(msg, 'device-1', true, 'com.whatsapp')).resolves.toBeDefined()
     })
 
     it('allows valid com.whatsapp.w4b package', async () => {
       const msg = enqueueMsg('guard-7')
+      lockMsg(msg.id)
       stubShellForSend(mockAdb)
       await expect(engine.send(msg, 'device-1', true, 'com.whatsapp.w4b')).resolves.toBeDefined()
     })
@@ -354,6 +370,7 @@ describe('SendEngine', () => {
         idempotencyKey: 'chunk-1',
         senderNumber: '5543996835100',
       })
+      lockMsg(msg.id)
       stubShellForSend(mockAdb)
 
       await engine.send(msg, 'device-1')
@@ -374,6 +391,7 @@ describe('SendEngine', () => {
         idempotencyKey: 'chunk-2',
         senderNumber: '5543996835100',
       })
+      lockMsg(msg.id)
       // Force typing strategy (explicitly zero all others to avoid flaky chatlist selection)
       const typingStrategy = new SendStrategy({ prefillWeight: 0, searchWeight: 0, typingWeight: 100, chatlistWeight: 0 })
       const typingEngine = new SendEngine(mockAdb, queue, emitter, typingStrategy)
@@ -400,6 +418,7 @@ describe('SendEngine', () => {
         idempotencyKey: 'chunk-3',
         senderNumber: '5543996835100',
       })
+      lockMsg(msg.id)
       // Force typing strategy (explicitly zero all others to avoid flaky chatlist selection)
       const typingStrategy = new SendStrategy({ prefillWeight: 0, searchWeight: 0, typingWeight: 100, chatlistWeight: 0 })
       const typingEngine = new SendEngine(mockAdb, queue, emitter, typingStrategy)
@@ -423,6 +442,7 @@ describe('SendEngine', () => {
   describe('pre-send health check', () => {
     it('always sends KEYCODE_WAKEUP proactively', async () => {
       const msg = enqueueMsg('health-1')
+      lockMsg(msg.id)
       stubShellForSend(mockAdb)
 
       await engine.send(msg, 'device-1')
@@ -433,6 +453,7 @@ describe('SendEngine', () => {
 
     it('swipes to unlock if lock screen is showing', async () => {
       const msg = enqueueMsg('health-2')
+      lockMsg(msg.id)
       const shellMock = mockAdb.shell as ReturnType<typeof vi.fn>
 
       shellMock.mockImplementation(async (_serial: string, cmd: string) => {
@@ -461,6 +482,7 @@ describe('SendEngine', () => {
         idempotencyKey: 'search-1',
         senderNumber: '5543996835100',
       })
+      lockMsg(msg.id)
       const searchStrategy = new SendStrategy({ prefillWeight: 0, searchWeight: 100, typingWeight: 0, chatlistWeight: 0 })
       const searchEngine = new SendEngine(mockAdb, queue, emitter, searchStrategy)
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -487,6 +509,7 @@ describe('SendEngine', () => {
         idempotencyKey: 'search-2',
         senderNumber: '5543996835100',
       })
+      lockMsg(msg.id)
       const searchStrategy = new SendStrategy({ prefillWeight: 0, searchWeight: 100, typingWeight: 0, chatlistWeight: 0 })
       const searchEngine = new SendEngine(mockAdb, queue, emitter, searchStrategy)
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -514,6 +537,7 @@ describe('SendEngine', () => {
         idempotencyKey: 'search-3',
         senderNumber: '5543996835100',
       })
+      lockMsg(msg.id)
       const searchStrategy = new SendStrategy({ prefillWeight: 0, searchWeight: 100, typingWeight: 0, chatlistWeight: 0 })
       const searchEngine = new SendEngine(mockAdb, queue, emitter, searchStrategy)
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -546,6 +570,7 @@ describe('SendEngine', () => {
         idempotencyKey: 'search-4',
         senderNumber: '5543996835100',
       })
+      lockMsg(msg.id)
       const searchStrategy = new SendStrategy({ prefillWeight: 0, searchWeight: 100, typingWeight: 0, chatlistWeight: 0 })
       const searchEngine = new SendEngine(mockAdb, queue, emitter, searchStrategy)
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -586,6 +611,7 @@ describe('SendEngine', () => {
         idempotencyKey: 'search-5',
         senderNumber: '5543996835100',
       })
+      lockMsg(msg.id)
       const searchStrategy = new SendStrategy({ prefillWeight: 0, searchWeight: 100, typingWeight: 0, chatlistWeight: 0 })
       const searchEngine = new SendEngine(mockAdb, queue, emitter, searchStrategy)
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -713,6 +739,7 @@ describe('SendEngine', () => {
         idempotencyKey: 'chatlist-dispatch-1',
         senderNumber: '5543996835100',
       })
+      lockMsg(msg.id)
 
       const chatlistStrategy = new SendStrategy({ prefillWeight: 0, searchWeight: 0, typingWeight: 0, chatlistWeight: 100 })
       const chatlistEngine = new SendEngine(mockAdb, queue, emitter, chatlistStrategy)

--- a/packages/core/src/engine/send-engine.ts
+++ b/packages/core/src/engine/send-engine.ts
@@ -104,7 +104,7 @@ export class SendEngine {
     let method: string = 'unknown' // enrichment: populated in text/media branch, used in emit
 
     try {
-      this.queue.updateStatus(message.id, 'sending')
+      this.queue.updateStatus(message.id, 'locked', 'sending')
       this.emitter.emit('message:sending', { id: message.id, deviceSerial })
 
       // Normalize and validate phone number (accept +55, spaces, hyphens — strip to digits)
@@ -260,7 +260,7 @@ export class SendEngine {
       }
 
       const durationMs = Date.now() - startTime
-      this.queue.updateStatus(message.id, 'sent')
+      this.queue.updateStatus(message.id, 'sending', 'sent')
       this.emitter.emit('message:sent', {
         id: message.id,
         sentAt: new Date().toISOString(),
@@ -275,15 +275,8 @@ export class SendEngine {
 
       return { screenshot, durationMs, contactRegistered, dialogsDismissed }
     } catch (err) {
-      try { this.queue.updateStatus(message.id, 'failed') } catch { /* DB may be closed */ }
-      this.emitter.emit('message:failed', {
-        id: message.id,
-        error: err instanceof Error ? err.message : String(err),
-        attempts: message.attempts,
-        senderNumber: message.senderNumber ?? undefined,
-        lastStrategyMethod: method,
-      })
-
+      // Status transitions on failure are handled by the caller (worker-orchestrator or manual send)
+      // so we only clean up device state here and re-throw
       try { await this.ensureCleanState(deviceSerial, appPackage) } catch { /* device may be disconnected */ }
 
       throw err

--- a/packages/core/src/engine/sender-mapping.test.ts
+++ b/packages/core/src/engine/sender-mapping.test.ts
@@ -48,7 +48,7 @@ describe('SenderMapping', () => {
       })
 
       expect(result.id).toBeDefined()
-      expect(result.phone_number).toBe('+554396837945')
+      expect(result.phone_number).toBe('554396837945')
       expect(result.device_serial).toBe('9b01005930533036')
       expect(result.profile_id).toBe(0)
       expect(result.app_package).toBe('com.whatsapp')
@@ -99,7 +99,7 @@ describe('SenderMapping', () => {
 
       const result = mapping.getByPhone('+554396837945')
       expect(result).not.toBeNull()
-      expect(result!.phone_number).toBe('+554396837945')
+      expect(result!.phone_number).toBe('554396837945')
     })
 
     it('returns null for unknown phone', () => {
@@ -114,7 +114,7 @@ describe('SenderMapping', () => {
         profileId: 0,
         appPackage: 'com.whatsapp',
       })
-      mapping.deactivate('+554396837945')
+      mapping.deactivate('554396837945')
 
       const result = mapping.getByPhone('+554396837945')
       expect(result).toBeNull()
@@ -153,11 +153,11 @@ describe('SenderMapping', () => {
         profileId: 0,
         appPackage: 'com.whatsapp.w4b',
       })
-      mapping.deactivate('+554396837844')
+      mapping.deactivate('554396837844')
 
       const all = mapping.listAll()
       expect(all).toHaveLength(1)
-      expect(all[0].phone_number).toBe('+554396837945')
+      expect(all[0].phone_number).toBe('554396837945')
     })
   })
 
@@ -170,7 +170,7 @@ describe('SenderMapping', () => {
         appPackage: 'com.whatsapp',
       })
 
-      const updated = mapping.update('+554396837945', {
+      const updated = mapping.update('554396837945', {
         deviceSerial: 'NEW_DEVICE_001',
         profileId: 10,
       })
@@ -195,10 +195,10 @@ describe('SenderMapping', () => {
         appPackage: 'com.whatsapp',
       })
 
-      mapping.deactivate('+554396837945')
+      mapping.deactivate('554396837945')
 
       // Direct query to verify (getByPhone filters inactive)
-      const row = db.prepare('SELECT active FROM sender_mapping WHERE phone_number = ?').get('+554396837945') as { active: number }
+      const row = db.prepare('SELECT active FROM sender_mapping WHERE phone_number = ?').get('554396837945') as { active: number }
       expect(row.active).toBe(0)
     })
   })
@@ -212,10 +212,10 @@ describe('SenderMapping', () => {
         appPackage: 'com.whatsapp',
       })
 
-      const deleted = mapping.remove('+554396837945')
+      const deleted = mapping.remove('554396837945')
       expect(deleted).toBe(true)
 
-      const row = db.prepare('SELECT * FROM sender_mapping WHERE phone_number = ?').get('+554396837945')
+      const row = db.prepare('SELECT * FROM sender_mapping WHERE phone_number = ?').get('554396837945')
       expect(row).toBeUndefined()
     })
 
@@ -259,11 +259,11 @@ describe('SenderMapping', () => {
         deviceSerial: '9b01005930533036',
       })
 
-      mapping.pauseSender('+554396837945', 'manual maintenance')
+      mapping.pauseSender('554396837945', 'manual maintenance')
 
       const row = db.prepare(
         'SELECT paused, paused_at, paused_reason FROM sender_mapping WHERE phone_number = ?',
-      ).get('+554396837945') as { paused: number; paused_at: string | null; paused_reason: string | null }
+      ).get('554396837945') as { paused: number; paused_at: string | null; paused_reason: string | null }
 
       expect(row.paused).toBe(1)
       expect(row.paused_at).toBeTruthy()
@@ -276,11 +276,11 @@ describe('SenderMapping', () => {
         deviceSerial: '9b01005930533036',
       })
 
-      mapping.pauseSender('+554396837945')
+      mapping.pauseSender('554396837945')
 
       const row = db.prepare(
         'SELECT paused, paused_reason FROM sender_mapping WHERE phone_number = ?',
-      ).get('+554396837945') as { paused: number; paused_reason: string | null }
+      ).get('554396837945') as { paused: number; paused_reason: string | null }
 
       expect(row.paused).toBe(1)
       expect(row.paused_reason).toBeNull()
@@ -294,12 +294,12 @@ describe('SenderMapping', () => {
         deviceSerial: '9b01005930533036',
       })
 
-      mapping.pauseSender('+554396837945', 'testing')
-      mapping.resumeSender('+554396837945')
+      mapping.pauseSender('554396837945', 'testing')
+      mapping.resumeSender('554396837945')
 
       const row = db.prepare(
         'SELECT paused, paused_at, paused_reason FROM sender_mapping WHERE phone_number = ?',
-      ).get('+554396837945') as { paused: number; paused_at: string | null; paused_reason: string | null }
+      ).get('554396837945') as { paused: number; paused_at: string | null; paused_reason: string | null }
 
       expect(row.paused).toBe(0)
       expect(row.paused_at).toBeNull()
@@ -314,8 +314,8 @@ describe('SenderMapping', () => {
         deviceSerial: '9b01005930533036',
       })
 
-      mapping.pauseSender('+554396837945')
-      expect(mapping.isPaused('+554396837945')).toBe(true)
+      mapping.pauseSender('554396837945')
+      expect(mapping.isPaused('554396837945')).toBe(true)
     })
 
     it('returns false for non-paused sender', () => {
@@ -324,11 +324,11 @@ describe('SenderMapping', () => {
         deviceSerial: '9b01005930533036',
       })
 
-      expect(mapping.isPaused('+554396837945')).toBe(false)
+      expect(mapping.isPaused('554396837945')).toBe(false)
     })
 
     it('returns false for unknown sender', () => {
-      expect(mapping.isPaused('+559999999999')).toBe(false)
+      expect(mapping.isPaused('559999999999')).toBe(false)
     })
 
     it('returns false after resume', () => {
@@ -337,9 +337,9 @@ describe('SenderMapping', () => {
         deviceSerial: '9b01005930533036',
       })
 
-      mapping.pauseSender('+554396837945')
-      mapping.resumeSender('+554396837945')
-      expect(mapping.isPaused('+554396837945')).toBe(false)
+      mapping.pauseSender('554396837945')
+      mapping.resumeSender('554396837945')
+      expect(mapping.isPaused('554396837945')).toBe(false)
     })
   })
 
@@ -349,7 +349,7 @@ describe('SenderMapping', () => {
         phoneNumber: '+554396837945',
         deviceSerial: '9b01005930533036',
       })
-      mapping.pauseSender('+554396837945', 'quota reached')
+      mapping.pauseSender('554396837945', 'quota reached')
 
       const all = mapping.listAll()
       expect(all).toHaveLength(1)
@@ -374,7 +374,7 @@ describe('SenderMapping', () => {
 
       const result = mapping.resolveSenderChain(senders)
       expect(result).not.toBeNull()
-      expect(result!.mapping.phone_number).toBe('+554396837945')
+      expect(result!.mapping.phone_number).toBe('554396837945')
       expect(result!.sender.role).toBe('primary')
     })
 
@@ -394,7 +394,7 @@ describe('SenderMapping', () => {
 
       const result = mapping.resolveSenderChain(senders)
       expect(result).not.toBeNull()
-      expect(result!.mapping.phone_number).toBe('+554396837844')
+      expect(result!.mapping.phone_number).toBe('554396837844')
       expect(result!.sender.role).toBe('overflow')
     })
 

--- a/packages/core/src/engine/sender-mapping.ts
+++ b/packages/core/src/engine/sender-mapping.ts
@@ -50,6 +50,11 @@ export interface ResolvedSender {
 export class SenderMapping {
   constructor(private db: Database.Database) {}
 
+  /** Decision #39: Normalize phone to digits-only (Postel's Law) */
+  private normalizePhone(phone: string): string {
+    return phone.replace(/\D/g, '')
+  }
+
   initialize(): void {
     this.db.exec(`
       CREATE TABLE IF NOT EXISTS sender_mapping (
@@ -86,7 +91,7 @@ export class SenderMapping {
       RETURNING *
     `).get(
       id,
-      params.phoneNumber,
+      this.normalizePhone(params.phoneNumber),
       params.deviceSerial,
       params.profileId ?? 0,
       params.appPackage ?? 'com.whatsapp',
@@ -99,7 +104,7 @@ export class SenderMapping {
   getByPhone(phoneNumber: string): SenderMappingRecord | null {
     const row = this.db.prepare(
       'SELECT * FROM sender_mapping WHERE phone_number = ? AND active = 1',
-    ).get(phoneNumber) as SenderMappingRecord | undefined
+    ).get(this.normalizePhone(phoneNumber)) as SenderMappingRecord | undefined
     return row ?? null
   }
 
@@ -198,7 +203,8 @@ export class SenderMapping {
   resolveSenderChain(senders: SenderConfig[]): ResolvedSender | null {
     for (const sender of senders) {
       const record = this.getByPhone(sender.phone)
-      if (record) {
+      // Q2: skip paused senders
+      if (record && record.paused === 0) {
         return { mapping: record, sender }
       }
     }

--- a/packages/core/src/engine/worker-orchestrator.test.ts
+++ b/packages/core/src/engine/worker-orchestrator.test.ts
@@ -194,9 +194,11 @@ describe('WorkerOrchestrator', () => {
     const msg = enqueueTestMessage(deps)
 
     // Mock engine.send to succeed — must also update status because the real
-    // SendEngine.send() calls queue.updateStatus(id, 'sent') internally.
+    // SendEngine.send() calls queue.updateStatus(id, 'locked', 'sending') then
+    // queue.updateStatus(id, 'sending', 'sent') internally.
     vi.spyOn(deps.engine, 'send').mockImplementation(async (message) => {
-      deps.queue.updateStatus(message.id, 'sent')
+      deps.queue.updateStatus(message.id, 'locked', 'sending')
+      deps.queue.updateStatus(message.id, 'sending', 'sent')
       return { screenshot: Buffer.from('ok'), durationMs: 100, contactRegistered: false, dialogsDismissed: 0 }
     })
 
@@ -266,7 +268,8 @@ describe('WorkerOrchestrator', () => {
     enqueueTestMessage(deps)
 
     vi.spyOn(deps.engine, 'send').mockImplementation(async (message) => {
-      deps.queue.updateStatus(message.id, 'sent')
+      deps.queue.updateStatus(message.id, 'locked', 'sending')
+      deps.queue.updateStatus(message.id, 'sending', 'sent')
       return { screenshot: Buffer.from('ok'), durationMs: 50, contactRegistered: false, dialogsDismissed: 0 }
     })
 
@@ -284,8 +287,11 @@ describe('WorkerOrchestrator', () => {
     seedSenderMapping(deps)
     enqueueTestMessage(deps)
 
-    // ADB send fails
-    vi.spyOn(deps.engine, 'send').mockRejectedValue(new Error('ADB failed'))
+    // ADB send fails — simulate real engine behavior: transition locked→sending, then throw
+    vi.spyOn(deps.engine, 'send').mockImplementation(async (message) => {
+      deps.queue.updateStatus(message.id, 'locked', 'sending')
+      throw new Error('ADB failed')
+    })
     // WAHA fallback also fails (already mocked to reject in createDeps, but be explicit)
     vi.spyOn(deps.wahaFallback, 'send').mockRejectedValue(new Error('WAHA down'))
 
@@ -306,8 +312,11 @@ describe('WorkerOrchestrator', () => {
     expect(msg.attempts).toBe(0)
     expect(msg.maxRetries).toBe(3)
 
-    // ADB send fails
-    vi.spyOn(deps.engine, 'send').mockRejectedValue(new Error('ADB failed'))
+    // ADB send fails — simulate real engine behavior: transition locked→sending, then throw
+    vi.spyOn(deps.engine, 'send').mockImplementation(async (message) => {
+      deps.queue.updateStatus(message.id, 'locked', 'sending')
+      throw new Error('ADB failed')
+    })
     // WAHA fallback also fails
     vi.spyOn(deps.wahaFallback, 'send').mockRejectedValue(new Error('WAHA down'))
 
@@ -329,8 +338,11 @@ describe('WorkerOrchestrator', () => {
     // Simulate message already at attempts=2 (maxRetries=3 → 2+1 >= 3 → permanent fail)
     deps.db.prepare('UPDATE messages SET attempts = 2 WHERE id = ?').run(msg.id)
 
-    // ADB send fails
-    vi.spyOn(deps.engine, 'send').mockRejectedValue(new Error('ADB failed'))
+    // ADB send fails — simulate real engine behavior: transition locked→sending, then throw
+    vi.spyOn(deps.engine, 'send').mockImplementation(async (message) => {
+      deps.queue.updateStatus(message.id, 'locked', 'sending')
+      throw new Error('ADB failed')
+    })
     // WAHA fallback also fails
     vi.spyOn(deps.wahaFallback, 'send').mockRejectedValue(new Error('WAHA down'))
 
@@ -389,7 +401,8 @@ describe('WorkerOrchestrator', () => {
     const processedDevices: string[] = []
     vi.spyOn(deps.engine, 'send').mockImplementation(async (message, deviceSerial) => {
       processedDevices.push(deviceSerial as string)
-      deps.queue.updateStatus(message.id, 'sent')
+      deps.queue.updateStatus(message.id, 'locked', 'sending')
+      deps.queue.updateStatus(message.id, 'sending', 'sent')
       return { screenshot: Buffer.from('ok'), durationMs: 50, contactRegistered: false, dialogsDismissed: 0 }
     })
 

--- a/packages/core/src/engine/worker-orchestrator.ts
+++ b/packages/core/src/engine/worker-orchestrator.ts
@@ -43,6 +43,8 @@ export class WorkerOrchestrator {
   private deviceForegroundUser = new Map<string, number>()
   private cappedSendersCooldown = new Map<string, number>()
   private lastWindowLogAt: number | null = null
+  private tickBackoffMs = 5_000
+  private readonly MAX_TICK_BACKOFF_MS = 60_000
   private sendMetadata = new Map<string, {
     profileId: number; userSwitched: boolean; ts: number;
     appPackage: string; senderNumber: string | null; isFirstContact: boolean;
@@ -52,6 +54,11 @@ export class WorkerOrchestrator {
 
   get isRunning(): boolean {
     return this.devicesRunning.size > 0
+  }
+
+  /** R7/Decision #15: Dynamic tick interval with exponential backoff */
+  getTickInterval(): number {
+    return this.tickBackoffMs
   }
 
   async processMessage(message: Message, deviceSerial: string, isFirstInBatch = true, appPackage = 'com.whatsapp'): Promise<boolean> {
@@ -158,11 +165,23 @@ export class WorkerOrchestrator {
 
     const { deviceManager } = this.deps
     const devices = deviceManager.getDevices().filter(d => d.status === 'online')
-    if (devices.length === 0) return
+    if (devices.length === 0) {
+      // R7/Decision #15: backoff when no devices
+      this.tickBackoffMs = Math.min(this.tickBackoffMs * 2, this.MAX_TICK_BACKOFF_MS)
+      return
+    }
 
     // Process each online device in parallel (each device runs sequentially within)
     const promises = devices.map(device => this.tickDevice(device.serial))
-    await Promise.allSettled(promises)
+    const results = await Promise.allSettled(promises)
+
+    // R7: Reset backoff if any device processed messages successfully
+    const anyActivity = results.some(r => r.status === 'fulfilled')
+    if (anyActivity) {
+      this.tickBackoffMs = 5_000
+    } else {
+      this.tickBackoffMs = Math.min(this.tickBackoffMs * 2, this.MAX_TICK_BACKOFF_MS)
+    }
   }
 
   private async tickDevice(deviceSerial: string): Promise<void> {

--- a/packages/core/src/engine/worker-orchestrator.ts
+++ b/packages/core/src/engine/worker-orchestrator.ts
@@ -65,29 +65,28 @@ export class WorkerOrchestrator {
     } catch (adbErr) {
       logger.warn({ messageId: message.id, err: adbErr }, 'Worker: ADB send failed, attempting WAHA fallback')
 
-      // Reset status to 'sending' to suppress premature 'failed' callback
-      try { queue.updateStatus(message.id, 'sending') } catch { /* ignore */ }
-
+      // Message is still in 'sending' (send-engine no longer sets 'failed')
       try {
         const fallbackResult = await wahaFallback.send(message)
         logger.info({ messageId: message.id, wahaMessageId: fallbackResult.wahaMessageId }, 'Worker: WAHA fallback succeeded')
-        queue.updateStatus(message.id, 'sent')
+        queue.updateStatus(message.id, 'sending', 'sent')
         emitter.emit('message:sent', { id: message.id, sentAt: new Date().toISOString(), durationMs: 0, deviceSerial, contactRegistered: false, dialogsDismissed: 0 })
         sendSuccess = true
         usedFallback = true
       } catch (wahaErr) {
         logger.error({ messageId: message.id, err: wahaErr }, 'Worker: WAHA fallback also failed')
-        if (message.attempts + 1 < message.maxRetries) {
-          const requeued = queue.requeueForRetry(message.id)
-          logger.warn({ messageId: message.id, attempts: requeued.attempts, maxRetries: message.maxRetries }, 'Worker: message requeued for retry')
-        } else {
-          queue.updateStatus(message.id, 'permanently_failed')
+        const totalAttempts = message.attempts + 1
+        if (totalAttempts >= message.maxRetries) {
+          queue.markPermanentlyFailed(message.id, totalAttempts)
           emitter.emit('message:failed', {
             id: message.id,
             error: `ADB and WAHA fallback both failed after ${message.maxRetries} attempts: ${wahaErr instanceof Error ? wahaErr.message : String(wahaErr)}`,
-            attempts: message.attempts + 1,
+            attempts: totalAttempts,
             senderNumber: message.senderNumber ?? undefined,
           })
+        } else {
+          const requeued = queue.requeueForRetry(message.id)
+          logger.warn({ messageId: message.id, attempts: requeued.attempts, maxRetries: message.maxRetries }, 'Worker: message requeued for retry')
         }
       }
     }
@@ -203,7 +202,7 @@ export class WorkerOrchestrator {
         const lastCapped = this.cappedSendersCooldown.get(senderNumber)
         if (lastCapped !== undefined && Date.now() - lastCapped < 60_000) {
           for (const msg of batch) {
-            try { queue.updateStatus(msg.id, 'queued') } catch { /* ignore */ }
+            try { queue.updateStatus(msg.id, 'locked', 'queued') } catch { /* ignore */ }
           }
           return
         }
@@ -220,7 +219,7 @@ export class WorkerOrchestrator {
           logger.warn({ senderNumber, dailyCount, max: effectiveCap }, 'Worker: sender daily limit reached, skipping batch')
           this.cappedSendersCooldown.set(senderNumber, Date.now())
           for (const msg of batch) {
-            try { queue.updateStatus(msg.id, 'queued') } catch { /* ignore */ }
+            try { queue.updateStatus(msg.id, 'locked', 'queued') } catch { /* ignore */ }
           }
           return
         }
@@ -230,7 +229,7 @@ export class WorkerOrchestrator {
       if (senderNumber && senderHealth.isQuarantined(senderNumber)) {
         logger.warn({ senderNumber }, 'Worker: sender quarantined, skipping batch')
         for (const msg of batch) {
-          try { queue.updateStatus(msg.id, 'queued') } catch { /* ignore */ }
+          try { queue.updateStatus(msg.id, 'locked', 'queued') } catch { /* ignore */ }
         }
         return // finally block releases mutex
       }
@@ -239,7 +238,7 @@ export class WorkerOrchestrator {
       if (senderNumber && senderMapping.isPaused(senderNumber)) {
         logger.info({ senderNumber }, 'Worker: sender paused, skipping batch')
         for (const msg of batch) {
-          try { queue.updateStatus(msg.id, 'queued') } catch { /* ignore */ }
+          try { queue.updateStatus(msg.id, 'locked', 'queued') } catch { /* ignore */ }
         }
         return
       }

--- a/packages/core/src/monitor/health-collector.test.ts
+++ b/packages/core/src/monitor/health-collector.test.ts
@@ -188,8 +188,10 @@ describe('HealthCollector', () => {
         INSERT INTO health_snapshots (serial, battery_percent, temperature_celsius, ram_available_mb, storage_free_bytes, wifi_connected, collected_at)
         VALUES (?, ?, ?, ?, ?, ?, ?)
       `)
-      stmt.run('ABC123', 80, 30.0, 1024, 12000000000, 1, '2026-03-20T10:00:00Z')
-      stmt.run('ABC123', 75, 31.0, 900, 11000000000, 1, '2026-04-02T12:00:00Z')
+      const eightDaysAgo = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString()
+      const oneDayAgo = new Date(Date.now() - 1 * 24 * 60 * 60 * 1000).toISOString()
+      stmt.run('ABC123', 80, 30.0, 1024, 12000000000, 1, eightDaysAgo)
+      stmt.run('ABC123', 75, 31.0, 900, 11000000000, 1, oneDayAgo)
 
       const removed = collector.cleanup()
 

--- a/packages/core/src/plugins/callback-delivery.test.ts
+++ b/packages/core/src/plugins/callback-delivery.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import Database from 'better-sqlite3'
+import { createHmac } from 'node:crypto'
 import { CallbackDelivery } from './callback-delivery.js'
 import { PluginRegistry } from './plugin-registry.js'
 import type { ResultCallback, AckCallback, ResponseCallback, FailedCallbackRecord, DeliveryInfo } from './types.js'
@@ -122,6 +123,35 @@ describe('CallbackDelivery', () => {
       const headers = init.headers as Record<string, string>
       expect(headers['X-Dispatch-Signature']).toBeDefined()
       expect(headers['X-Dispatch-Signature'].length).toBeGreaterThan(0)
+    })
+
+    it('T3: HMAC signature matches exact cryptographic computation', async () => {
+      registerOralsin()
+      mockFetch.mockResolvedValueOnce(new Response('OK', { status: 200 }))
+
+      const payload: ResultCallback = {
+        idempotency_key: 'hmac-verify-key',
+        status: 'sent',
+        sent_at: '2026-04-13T20:00:00Z',
+        delivery: { ...baseDelivery, elapsed_ms: 7777 },
+        error: null,
+        context: { clinic_id: 'uuid-1' },
+      }
+
+      await delivery.sendResultCallback('oralsin', 'msg-hmac', payload)
+
+      const [, init] = mockFetch.mock.calls[0]
+      const headers = init.headers as Record<string, string>
+      const body = init.body as string
+
+      // Compute expected HMAC independently
+      const expectedHmac = createHmac('sha256', 'test-hmac-secret')
+        .update(body)
+        .digest('hex')
+
+      expect(headers['X-Dispatch-Signature']).toBe(expectedHmac)
+      // Verify it is a valid 64-char hex string (SHA-256 output)
+      expect(headers['X-Dispatch-Signature']).toMatch(/^[a-f0-9]{64}$/)
     })
 
     it('includes context pass-through in callback body', async () => {
@@ -264,6 +294,136 @@ describe('CallbackDelivery', () => {
 
       vi.useRealTimers()
     })
+
+    it('T9: stops retrying on 400 after first attempt (non-retryable)', async () => {
+      vi.useFakeTimers()
+      registerOralsin()
+      mockFetch.mockResolvedValue(new Response('Bad Request', { status: 400 }))
+
+      const promise = delivery.sendResultCallback('oralsin', 'msg-400', {
+        idempotency_key: 'test-400',
+        status: 'sent',
+        sent_at: '2026-04-13T20:00:00Z',
+        delivery: { ...baseDelivery },
+        error: null,
+      })
+
+      // Advance past all possible backoff windows
+      await vi.advanceTimersByTimeAsync(200_000)
+      await promise
+
+      // 400 = client error, should NOT retry after first attempt
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+
+      // Should still be persisted as failed
+      const failed = delivery.listFailedCallbacks()
+      expect(failed).toHaveLength(1)
+      expect(failed[0].last_error).toContain('HTTP 400')
+      vi.useRealTimers()
+    })
+
+    it('T9: retries on 503 with short backoff [0, 1s, 2s, 4s] (Decision #40)', async () => {
+      vi.useFakeTimers()
+      registerOralsin()
+      // First attempt returns 503, then 3 more 503 retries with short backoff
+      mockFetch.mockResolvedValue(new Response('Service Unavailable', { status: 503 }))
+
+      const promise = delivery.sendResultCallback('oralsin', 'msg-503', {
+        idempotency_key: 'test-503',
+        status: 'sent',
+        sent_at: '2026-04-13T20:00:00Z',
+        delivery: { ...baseDelivery },
+        error: null,
+      })
+
+      // Attempt 1 fires immediately (backoff[0] = 0)
+      await vi.advanceTimersByTimeAsync(0)
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+
+      // 503 triggers short backoff inline: [0, 1s, 2s, 4s]
+      // 503 retry 1 at +1s
+      await vi.advanceTimersByTimeAsync(1_000)
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+
+      // 503 retry 2 at +2s
+      await vi.advanceTimersByTimeAsync(2_000)
+      expect(mockFetch).toHaveBeenCalledTimes(3)
+
+      // 503 retry 3 at +4s
+      await vi.advanceTimersByTimeAsync(4_000)
+      expect(mockFetch).toHaveBeenCalledTimes(4)
+
+      // Advance remaining to drain — no more retries after 503 exhausted
+      await vi.advanceTimersByTimeAsync(200_000)
+      await promise
+
+      // Total: 1 original + 3 short backoff retries = 4 calls
+      expect(mockFetch).toHaveBeenCalledTimes(4)
+
+      // Persisted as failed
+      const failed = delivery.listFailedCallbacks()
+      expect(failed).toHaveLength(1)
+      expect(failed[0].last_error).toContain('HTTP 503')
+      vi.useRealTimers()
+    })
+
+    it('T9: 503 succeeds on second short-backoff retry', async () => {
+      vi.useFakeTimers()
+      registerOralsin()
+      mockFetch
+        .mockResolvedValueOnce(new Response('Service Unavailable', { status: 503 })) // attempt 1
+        .mockResolvedValueOnce(new Response('Service Unavailable', { status: 503 })) // 503 retry 1
+        .mockResolvedValueOnce(new Response('OK', { status: 200 })) // 503 retry 2 succeeds
+
+      const promise = delivery.sendResultCallback('oralsin', 'msg-503-ok', {
+        idempotency_key: 'test-503-ok',
+        status: 'sent',
+        sent_at: '2026-04-13T20:00:00Z',
+        delivery: { ...baseDelivery },
+        error: null,
+      })
+
+      // Attempt 1 fires immediately
+      await vi.advanceTimersByTimeAsync(0)
+      // 503 retry 1 at +1s
+      await vi.advanceTimersByTimeAsync(1_000)
+      // 503 retry 2 at +2s
+      await vi.advanceTimersByTimeAsync(2_000)
+      await promise
+
+      expect(mockFetch).toHaveBeenCalledTimes(3)
+
+      // No failed callbacks — it succeeded
+      const failed = delivery.listFailedCallbacks()
+      expect(failed).toHaveLength(0)
+      vi.useRealTimers()
+    })
+
+    it('retries all 4 times on 500 (server error)', async () => {
+      vi.useFakeTimers()
+      registerOralsin()
+      mockFetch.mockResolvedValue(new Response('Internal Server Error', { status: 500 }))
+
+      const promise = delivery.sendResultCallback('oralsin', 'msg-500', {
+        idempotency_key: 'test-500',
+        status: 'sent',
+        sent_at: '2026-04-13T20:00:00Z',
+        delivery: { ...baseDelivery },
+        error: null,
+      })
+
+      await vi.advanceTimersByTimeAsync(5_000)
+      await vi.advanceTimersByTimeAsync(30_000)
+      await vi.advanceTimersByTimeAsync(120_000)
+      await promise
+
+      expect(mockFetch).toHaveBeenCalledTimes(4)
+
+      const failed = delivery.listFailedCallbacks()
+      expect(failed).toHaveLength(1)
+      expect(failed[0].last_error).toContain('HTTP 500')
+      vi.useRealTimers()
+    })
   })
 
   describe('sendAckCallback', () => {
@@ -372,6 +532,154 @@ describe('CallbackDelivery', () => {
       // Should be removed from failed list
       const remaining = delivery.listFailedCallbacks()
       expect(remaining).toHaveLength(0)
+    })
+
+    it('T12: increments attempts and updates last_error on failed retry', async () => {
+      vi.useFakeTimers()
+      registerOralsin()
+      // Create a failed callback first
+      mockFetch.mockRejectedValue(new Error('ECONNREFUSED'))
+      const promise = delivery.sendResultCallback('oralsin', 'msg-retry-fail', {
+        idempotency_key: 'test-retry-fail',
+        status: 'sent',
+        sent_at: '2026-04-13T20:00:00Z',
+        delivery: { ...baseDelivery },
+        error: null,
+      })
+      await vi.advanceTimersByTimeAsync(155_000)
+      await promise
+      mockFetch.mockReset()
+      vi.useRealTimers()
+
+      const failedBefore = delivery.listFailedCallbacks()
+      expect(failedBefore).toHaveLength(1)
+      const originalAttempts = failedBefore[0].attempts
+      const failedId = failedBefore[0].id
+
+      // Retry with a different error
+      mockFetch.mockRejectedValueOnce(new Error('ETIMEDOUT'))
+      await delivery.retryFailedCallback(failedId)
+
+      // Verify: attempts incremented, last_error updated
+      const failedAfter = delivery.listFailedCallbacks()
+      expect(failedAfter).toHaveLength(1)
+      expect(failedAfter[0].attempts).toBe(originalAttempts + 1)
+      expect(failedAfter[0].last_error).toBe('ETIMEDOUT')
+    })
+
+    it('T12: updates last_error with HTTP status on non-ok response during retry', async () => {
+      vi.useFakeTimers()
+      registerOralsin()
+      // Create a failed callback first
+      mockFetch.mockRejectedValue(new Error('ECONNREFUSED'))
+      const promise = delivery.sendResultCallback('oralsin', 'msg-retry-http', {
+        idempotency_key: 'test-retry-http',
+        status: 'sent',
+        sent_at: '2026-04-13T20:00:00Z',
+        delivery: { ...baseDelivery },
+        error: null,
+      })
+      await vi.advanceTimersByTimeAsync(155_000)
+      await promise
+      mockFetch.mockReset()
+      vi.useRealTimers()
+
+      const failedBefore = delivery.listFailedCallbacks()
+      const failedId = failedBefore[0].id
+
+      // Retry returns 500
+      mockFetch.mockResolvedValueOnce(new Response('Internal Server Error', { status: 500 }))
+      await delivery.retryFailedCallback(failedId)
+
+      const failedAfter = delivery.listFailedCallbacks()
+      expect(failedAfter).toHaveLength(1)
+      expect(failedAfter[0].last_error).toContain('HTTP 500')
+      expect(failedAfter[0].last_error).toContain('Internal Server Error')
+    })
+
+    it('throws for non-existent failed callback id', async () => {
+      await expect(
+        delivery.retryFailedCallback('nonexistent-id'),
+      ).rejects.toThrow('Failed callback not found: nonexistent-id')
+    })
+  })
+
+  describe('AbortSignal timeout', () => {
+    it('aborts fetch when it exceeds HTTP timeout', async () => {
+      registerOralsin()
+
+      // Mock fetch that captures the signal and hangs
+      mockFetch.mockImplementation(
+        (_url: string, init: RequestInit) =>
+          new Promise((_resolve, reject) => {
+            // Listen for abort signal
+            if (init.signal) {
+              init.signal.addEventListener('abort', () => {
+                reject(new DOMException('The operation was aborted', 'AbortError'))
+              })
+            }
+          }),
+      )
+
+      // Create delivery with very short timeout for testing
+      const env = process.env.DISPATCH_HTTP_TIMEOUT_MS
+      process.env.DISPATCH_HTTP_TIMEOUT_MS = '50'
+      const shortTimeoutDelivery = new CallbackDelivery(db, registry, mockFetch)
+
+      // This should fail due to timeout and eventually persist to failed_callbacks
+      vi.useFakeTimers()
+      const promise = shortTimeoutDelivery.sendResultCallback('oralsin', 'msg-timeout', {
+        idempotency_key: 'test-timeout',
+        status: 'sent',
+        sent_at: '2026-04-13T20:00:00Z',
+        delivery: { ...baseDelivery },
+        error: null,
+      })
+
+      // Each attempt times out at 50ms, then backoff delays
+      // Advance enough for all 4 attempts + backoffs
+      for (let i = 0; i < 20; i++) {
+        await vi.advanceTimersByTimeAsync(50)
+      }
+      await vi.advanceTimersByTimeAsync(5_000)
+      for (let i = 0; i < 20; i++) {
+        await vi.advanceTimersByTimeAsync(50)
+      }
+      await vi.advanceTimersByTimeAsync(30_000)
+      for (let i = 0; i < 20; i++) {
+        await vi.advanceTimersByTimeAsync(50)
+      }
+      await vi.advanceTimersByTimeAsync(120_000)
+      for (let i = 0; i < 20; i++) {
+        await vi.advanceTimersByTimeAsync(50)
+      }
+      await promise
+
+      // Verify: the AbortError was caught and propagated
+      const failed = shortTimeoutDelivery.listFailedCallbacks()
+      expect(failed).toHaveLength(1)
+      expect(failed[0].last_error).toContain('abort')
+
+      process.env.DISPATCH_HTTP_TIMEOUT_MS = env
+      vi.useRealTimers()
+    })
+
+    it('passes AbortSignal to fetchFn', async () => {
+      registerOralsin()
+      mockFetch.mockResolvedValueOnce(new Response('OK', { status: 200 }))
+
+      await delivery.sendResultCallback('oralsin', 'msg-signal', {
+        idempotency_key: 'test-signal',
+        status: 'sent',
+        sent_at: '2026-04-13T20:00:00Z',
+        delivery: { ...baseDelivery },
+        error: null,
+      })
+
+      // Verify the fetch was called with a signal property
+      const [, init] = mockFetch.mock.calls[0]
+      expect(init.signal).toBeDefined()
+      expect(init.signal).toBeInstanceOf(AbortSignal)
     })
   })
 })

--- a/packages/core/src/plugins/callback-delivery.ts
+++ b/packages/core/src/plugins/callback-delivery.ts
@@ -2,14 +2,17 @@ import { createHmac } from 'node:crypto'
 import type Database from 'better-sqlite3'
 import { nanoid } from 'nanoid'
 import type { PluginRegistry } from './plugin-registry.js'
-import type { ResultCallback, AckCallback, ResponseCallback, FailedCallbackRecord } from './types.js'
+import type { ResultCallback, AckCallback, ResponseCallback, InterimFailureCallback, ExpiredCallback, FailedCallbackRecord, CallbackType } from './types.js'
 
 type FetchFn = (url: string, init: RequestInit) => Promise<Response>
 
 const MAX_RETRIES = 4
 
-/** Delays in ms before each attempt: attempt 1 = 0 (immediate), attempt 2 = 5s, attempt 3 = 30s, attempt 4 = 120s */
+/** Standard backoff: attempt 1 = 0 (immediate), 2 = 5s, 3 = 30s, 4 = 120s */
 const BACKOFF_DELAYS_MS = [0, 5_000, 30_000, 120_000] as const
+
+/** 503-specific short backoff: 0, 1s, 2s, 4s (Decision #40) */
+const BACKOFF_503_MS = [0, 1_000, 2_000, 4_000] as const
 
 function sleep(ms: number): Promise<void> {
   if (ms <= 0) return Promise.resolve()
@@ -17,23 +20,25 @@ function sleep(ms: number): Promise<void> {
 }
 
 export class CallbackDelivery {
-  // Cached prepared statements — initialized lazily on first use
   private stmtListFailed: Database.Statement | null = null
   private stmtGetFailed: Database.Statement | null = null
   private stmtDeleteFailed: Database.Statement | null = null
-  private stmtUpdateFailedAttempts: Database.Statement | null = null
+  private stmtUpdateFailed: Database.Statement | null = null
   private stmtInsertFailed: Database.Statement | null = null
+  private httpTimeoutMs: number
 
   constructor(
     private db: Database.Database,
     private registry: PluginRegistry,
     private fetchFn: FetchFn,
-  ) {}
+  ) {
+    this.httpTimeoutMs = parseInt(process.env.DISPATCH_HTTP_TIMEOUT_MS ?? '10000', 10)
+  }
 
   private getStmtListFailed(): Database.Statement {
     if (!this.stmtListFailed) {
       this.stmtListFailed = this.db.prepare(
-        'SELECT * FROM failed_callbacks ORDER BY created_at DESC',
+        'SELECT * FROM failed_callbacks WHERE attempts < 10 ORDER BY created_at DESC',
       )
     }
     return this.stmtListFailed
@@ -57,13 +62,13 @@ export class CallbackDelivery {
     return this.stmtDeleteFailed
   }
 
-  private getStmtUpdateFailedAttempts(): Database.Statement {
-    if (!this.stmtUpdateFailedAttempts) {
-      this.stmtUpdateFailedAttempts = this.db.prepare(
-        "UPDATE failed_callbacks SET attempts = attempts + 1, last_attempt_at = datetime('now') WHERE id = ?",
+  private getStmtUpdateFailed(): Database.Statement {
+    if (!this.stmtUpdateFailed) {
+      this.stmtUpdateFailed = this.db.prepare(
+        "UPDATE failed_callbacks SET attempts = attempts + 1, last_attempt_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now'), last_error = ? WHERE id = ?",
       )
     }
-    return this.stmtUpdateFailedAttempts
+    return this.stmtUpdateFailed
   }
 
   private getStmtInsertFailed(): Database.Statement {
@@ -91,6 +96,16 @@ export class CallbackDelivery {
     await this.sendCallback(pluginName, messageId, 'response', payload)
   }
 
+  async sendInterimFailureCallback(pluginName: string, messageId: string, payload: InterimFailureCallback): Promise<void> {
+    if (!pluginName) return
+    await this.sendCallback(pluginName, messageId, 'interim_failure', payload)
+  }
+
+  async sendExpiredCallback(pluginName: string, messageId: string, payload: ExpiredCallback): Promise<void> {
+    if (!pluginName) return
+    await this.sendCallback(pluginName, messageId, 'expired', payload)
+  }
+
   listFailedCallbacks(): FailedCallbackRecord[] {
     return this.getStmtListFailed().all() as FailedCallbackRecord[]
   }
@@ -107,7 +122,7 @@ export class CallbackDelivery {
     const signature = this.sign(body, plugin.hmac_secret)
 
     try {
-      const response = await this.fetchFn(plugin.webhook_url, {
+      const response = await this.fetchWithTimeout(plugin.webhook_url, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -118,18 +133,22 @@ export class CallbackDelivery {
       if (response.ok) {
         this.getStmtDeleteFailed().run(failedId)
       } else {
-        this.getStmtUpdateFailedAttempts().run(failedId)
+        // A6: capture response body in last_error
+        const bodyText = await response.text().catch(() => '')
+        const lastError = `HTTP ${response.status}: ${bodyText.slice(0, 500)}`
+        this.getStmtUpdateFailed().run(lastError, failedId)
       }
-    } catch {
-      this.getStmtUpdateFailedAttempts().run(failedId)
+    } catch (err) {
+      const lastError = err instanceof Error ? err.message : String(err)
+      this.getStmtUpdateFailed().run(lastError, failedId)
     }
   }
 
   private async sendCallback(
     pluginName: string,
     messageId: string,
-    callbackType: string,
-    payload: ResultCallback | AckCallback | ResponseCallback,
+    callbackType: CallbackType,
+    payload: ResultCallback | AckCallback | ResponseCallback | InterimFailureCallback | ExpiredCallback,
   ): Promise<void> {
     const plugin = this.registry.getPlugin(pluginName)
     if (!plugin) return
@@ -143,7 +162,7 @@ export class CallbackDelivery {
       await sleep(delay)
 
       try {
-        const response = await this.fetchFn(plugin.webhook_url, {
+        const response = await this.fetchWithTimeout(plugin.webhook_url, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
@@ -152,10 +171,29 @@ export class CallbackDelivery {
           body,
         })
         if (response.ok) return
-        lastError = `HTTP ${response.status}`
-        // 4xx = client error (non-retryable), 503 = orphaned/not-found (non-retryable)
+
+        // A5: capture response body in last_error
+        const bodyText = await response.text().catch(() => '')
+        lastError = `HTTP ${response.status}: ${bodyText.slice(0, 500)}`
+
+        // 4xx = client error (non-retryable)
         if (response.status >= 400 && response.status < 500) break
-        if (response.status === 503) break
+
+        // Decision #40: 503 is retryable with short backoff
+        if (response.status === 503) {
+          for (let retry503 = 1; retry503 < BACKOFF_503_MS.length; retry503++) {
+            await sleep(BACKOFF_503_MS[retry503])
+            const retryResponse = await this.fetchWithTimeout(plugin.webhook_url, {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json', 'X-Dispatch-Signature': signature },
+              body,
+            })
+            if (retryResponse.ok) return
+            const retryBodyText = await retryResponse.text().catch(() => '')
+            lastError = `HTTP ${retryResponse.status}: ${retryBodyText.slice(0, 500)}`
+          }
+          break // 503 retries exhausted
+        }
       } catch (err) {
         lastError = err instanceof Error ? err.message : String(err)
       }
@@ -172,6 +210,17 @@ export class CallbackDelivery {
       MAX_RETRIES,
       lastError,
     )
+  }
+
+  /** S15/R11: All outbound HTTP uses AbortSignal timeout */
+  private async fetchWithTimeout(url: string, init: RequestInit): Promise<Response> {
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => controller.abort(), this.httpTimeoutMs)
+    try {
+      return await this.fetchFn(url, { ...init, signal: controller.signal })
+    } finally {
+      clearTimeout(timeoutId)
+    }
   }
 
   private sign(body: string, secret: string): string {

--- a/packages/core/src/plugins/oralsin-plugin.ts
+++ b/packages/core/src/plugins/oralsin-plugin.ts
@@ -4,8 +4,10 @@ import type { DispatchEventName } from '../events/index.js'
 
 // ── Zod Schemas for request validation ──
 
+const phoneSchema = z.string().regex(/^\+?\d{10,15}$/, 'Must be 10-15 digits, optional + prefix')
+
 const senderSchema = z.object({
-  phone: z.string().min(10),
+  phone: phoneSchema,
   session: z.string().min(1),
   pair: z.string().min(1),
   role: z.enum(['primary', 'backup', 'overflow', 'reserve']),
@@ -24,16 +26,20 @@ const enqueueItemSchema = z.object({
   idempotency_key: z.string().min(1),
   correlation_id: z.string().optional(),
   patient: z.object({
-    phone: z.string().min(10),
+    phone: phoneSchema,
     name: z.string().min(1),
     patient_id: z.string().optional(),
   }),
   message: z.object({
-    text: z.string().min(1),
+    text: z.string().min(1).max(4096),
     template_id: z.string().optional(),
   }),
   senders: z.array(senderSchema).min(1),
-  context: z.record(z.unknown()).optional(),
+  context: z.record(z.unknown()).optional().superRefine((val, ctx) => {
+    if (val && JSON.stringify(val).length > 65536) {
+      ctx.addIssue({ code: 'custom', message: 'context exceeds 64KB' })
+    }
+  }),
   send_options: z
     .object({
       max_retries: z.number().int().min(1).max(10).optional(),
@@ -44,7 +50,7 @@ const enqueueItemSchema = z.object({
 
 const enqueueRequestSchema = z.union([
   enqueueItemSchema,
-  z.array(enqueueItemSchema).min(1),
+  z.array(enqueueItemSchema).min(1).max(500),
 ])
 
 // ── Plugin Implementation ──

--- a/packages/core/src/plugins/oralsin-sender-resolution.test.ts
+++ b/packages/core/src/plugins/oralsin-sender-resolution.test.ts
@@ -104,7 +104,7 @@ describe('OralsinPlugin sender resolution', () => {
 
     // Verify sender_number was set to the primary
     const msg = db.prepare('SELECT sender_number FROM messages WHERE id = ?').get(data.messages[0].id) as { sender_number: string }
-    expect(msg.sender_number).toBe('+554396837945')
+    expect(msg.sender_number).toBe('554396837945')
   })
 
   it('falls back to overflow when primary has no mapping', async () => {
@@ -128,7 +128,7 @@ describe('OralsinPlugin sender resolution', () => {
     const data = response.body as { enqueued: number; messages: Array<{ id: string }> }
 
     const msg = db.prepare('SELECT sender_number FROM messages WHERE id = ?').get(data.messages[0].id) as { sender_number: string }
-    expect(msg.sender_number).toBe('+554396837844')
+    expect(msg.sender_number).toBe('554396837844')
   })
 
   it('falls back to backup when overflow also missing', async () => {
@@ -152,7 +152,7 @@ describe('OralsinPlugin sender resolution', () => {
     const data = response.body as { enqueued: number; messages: Array<{ id: string }> }
 
     const msg = db.prepare('SELECT sender_number FROM messages WHERE id = ?').get(data.messages[0].id) as { sender_number: string }
-    expect(msg.sender_number).toBe('+554399991111')
+    expect(msg.sender_number).toBe('554399991111')
   })
 
   it('returns 422 when no sender can be resolved', async () => {
@@ -191,7 +191,7 @@ describe('OralsinPlugin sender resolution', () => {
     const data = response.body as { messages: Array<{ id: string }> }
     const msg = queue.getById(data.messages[0].id)
     expect(msg).not.toBeNull()
-    expect(msg!.senderNumber).toBe('+554396837945')
+    expect(msg!.senderNumber).toBe('554396837945')
   })
 
   it('stores senders_config as JSON for fallback use', async () => {

--- a/packages/core/src/plugins/plugin-e2e.test.ts
+++ b/packages/core/src/plugins/plugin-e2e.test.ts
@@ -1,0 +1,434 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import Database from 'better-sqlite3'
+import { createHmac } from 'node:crypto'
+import { CallbackDelivery } from './callback-delivery.js'
+import { PluginRegistry } from './plugin-registry.js'
+import { PluginEventBus } from './plugin-event-bus.js'
+import { DispatchEmitter } from '../events/index.js'
+import { MessageQueue } from '../queue/message-queue.js'
+import type { ResultCallback, DeliveryInfo } from './types.js'
+
+/**
+ * E2E Integration Test (T1) — Plugin Hardening Batch 9
+ *
+ * Tests the complete callback loop with mocked ADB:
+ *   enqueue -> dequeueBySender -> process (mocked send) -> message:sent
+ *   -> callback delivery with HMAC verification
+ */
+describe('Plugin E2E — Full Callback Loop', () => {
+  let db: Database.Database
+  let queue: MessageQueue
+  let registry: PluginRegistry
+  let emitter: DispatchEmitter
+  let eventBus: PluginEventBus
+  let callbackDelivery: CallbackDelivery
+  let mockFetch: ReturnType<typeof vi.fn>
+
+  const TEST_PLUGIN = 'oralsin'
+  const TEST_HMAC_SECRET = 'e2e-test-hmac-secret-32bytes-long'
+  const TEST_WEBHOOK_URL = 'https://oralsin.example.com/api/webhooks/dispatch/'
+  const TEST_DEVICE_SERIAL = '9b01005930533036340030832250ac'
+
+  const registerTestPlugin = () => {
+    registry.register({
+      name: TEST_PLUGIN,
+      version: '1.0.0',
+      webhookUrl: TEST_WEBHOOK_URL,
+      apiKey: 'test-api-key-1',
+      hmacSecret: TEST_HMAC_SECRET,
+      events: ['message:sent', 'message:failed'],
+    })
+  }
+
+  beforeEach(() => {
+    db = new Database(':memory:')
+    db.pragma('journal_mode = WAL')
+
+    // Initialize all modules on the same DB
+    queue = new MessageQueue(db)
+    queue.initialize()
+
+    registry = new PluginRegistry(db)
+    registry.initialize()
+
+    emitter = new DispatchEmitter()
+
+    eventBus = new PluginEventBus(registry, emitter)
+
+    mockFetch = vi.fn<(url: string, init: RequestInit) => Promise<Response>>()
+    callbackDelivery = new CallbackDelivery(db, registry, mockFetch)
+  })
+
+  afterEach(() => {
+    eventBus.destroy()
+    db.close()
+  })
+
+  it('enqueue -> dequeue -> status transitions -> message:sent -> callback with valid HMAC', async () => {
+    // 1. Register plugin
+    registerTestPlugin()
+
+    // 2. Enqueue a message with plugin_name
+    const msg = queue.enqueue({
+      to: '5543991938235',
+      body: 'Test E2E callback loop',
+      idempotencyKey: 'oralsin-sched-e2e-001',
+      pluginName: TEST_PLUGIN,
+      correlationId: 'pipeline-e2e-1',
+      senderNumber: '5537999001122',
+    })
+    expect(msg.status).toBe('queued')
+    expect(msg.pluginName).toBe(TEST_PLUGIN)
+
+    // 3. Dequeue (simulates worker picking up the message)
+    const batch = queue.dequeueBySender(TEST_DEVICE_SERIAL)
+    expect(batch).toHaveLength(1)
+    expect(batch[0].id).toBe(msg.id)
+    expect(batch[0].status).toBe('locked')
+
+    // 4. Transition: locked -> sending
+    const sending = queue.updateStatus(msg.id, 'locked', 'sending')
+    expect(sending.status).toBe('sending')
+
+    // 5. Transition: sending -> sent (simulates successful ADB send)
+    const sent = queue.updateStatus(msg.id, 'sending', 'sent')
+    expect(sent.status).toBe('sent')
+    expect(sent.sentAt).toBeTruthy()
+
+    // 6. Set up callback mock to capture the request
+    mockFetch.mockResolvedValueOnce(new Response('OK', { status: 200 }))
+
+    // 7. Build the callback payload (as the engine would)
+    const deliveryInfo: DeliveryInfo = {
+      message_id: null,
+      provider: 'adb',
+      sender_phone: '5537999001122',
+      sender_session: 'oralsin-1-4',
+      pair_used: 'MG-Guaxupe',
+      used_fallback: false,
+      elapsed_ms: 12345,
+      device_serial: TEST_DEVICE_SERIAL,
+      profile_id: 0,
+      char_count: 22,
+      contact_registered: false,
+      screenshot_url: `/api/v1/messages/${msg.id}/screenshot`,
+      dialogs_dismissed: 0,
+      user_switched: false,
+    }
+
+    const resultPayload: ResultCallback = {
+      idempotency_key: msg.idempotencyKey,
+      correlation_id: 'pipeline-e2e-1',
+      status: 'sent',
+      sent_at: sent.sentAt!,
+      delivery: deliveryInfo,
+      error: null,
+      context: { clinic_id: 'uuid-clinic', schedule_id: 'uuid-sched' },
+    }
+
+    // 8. Send callback (as the engine would after message:sent)
+    await callbackDelivery.sendResultCallback(TEST_PLUGIN, msg.id, resultPayload)
+
+    // 9. Verify: fetch was called once
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+
+    // 10. Verify: URL is correct
+    const [callUrl, callInit] = mockFetch.mock.calls[0]
+    expect(callUrl).toBe(TEST_WEBHOOK_URL)
+
+    // 11. Verify: payload is correct
+    const callBody = JSON.parse(callInit.body as string)
+    expect(callBody.idempotency_key).toBe('oralsin-sched-e2e-001')
+    expect(callBody.correlation_id).toBe('pipeline-e2e-1')
+    expect(callBody.status).toBe('sent')
+    expect(callBody.delivery.provider).toBe('adb')
+    expect(callBody.delivery.sender_phone).toBe('5537999001122')
+    expect(callBody.delivery.device_serial).toBe(TEST_DEVICE_SERIAL)
+    expect(callBody.context).toEqual({ clinic_id: 'uuid-clinic', schedule_id: 'uuid-sched' })
+
+    // 12. Verify: HMAC is cryptographically correct
+    const headers = callInit.headers as Record<string, string>
+    const expectedHmac = createHmac('sha256', TEST_HMAC_SECRET)
+      .update(callInit.body as string)
+      .digest('hex')
+    expect(headers['X-Dispatch-Signature']).toBe(expectedHmac)
+  })
+
+  it('enqueue batch -> dequeue -> mixed results -> callbacks for each', async () => {
+    registerTestPlugin()
+    mockFetch.mockResolvedValue(new Response('OK', { status: 200 }))
+
+    // Enqueue batch of 2 messages
+    const result = queue.enqueueBatch([
+      {
+        to: '5543991938235',
+        body: 'Batch msg 1',
+        idempotencyKey: 'oralsin-batch-001',
+        pluginName: TEST_PLUGIN,
+        senderNumber: '5537999001122',
+      },
+      {
+        to: '5543991938236',
+        body: 'Batch msg 2',
+        idempotencyKey: 'oralsin-batch-002',
+        pluginName: TEST_PLUGIN,
+        senderNumber: '5537999001122',
+      },
+    ])
+    expect(result.enqueued).toHaveLength(2)
+    expect(result.skipped).toHaveLength(0)
+
+    // Dequeue all by sender
+    const batch = queue.dequeueBySender(TEST_DEVICE_SERIAL)
+    expect(batch).toHaveLength(2)
+
+    // Send first message successfully
+    queue.updateStatus(batch[0].id, 'locked', 'sending')
+    queue.updateStatus(batch[0].id, 'sending', 'sent')
+
+    await callbackDelivery.sendResultCallback(TEST_PLUGIN, batch[0].id, {
+      idempotency_key: 'oralsin-batch-001',
+      status: 'sent',
+      sent_at: new Date().toISOString(),
+      delivery: {
+        message_id: null,
+        provider: 'adb',
+        sender_phone: '5537999001122',
+        sender_session: 'oralsin-1-4',
+        pair_used: 'MG-Guaxupe',
+        used_fallback: false,
+        elapsed_ms: 8000,
+        device_serial: TEST_DEVICE_SERIAL,
+        profile_id: 0,
+        char_count: 11,
+        contact_registered: false,
+        screenshot_url: null,
+        dialogs_dismissed: 0,
+        user_switched: false,
+      },
+      error: null,
+    })
+
+    // Second message fails
+    queue.updateStatus(batch[1].id, 'locked', 'sending')
+    queue.updateStatus(batch[1].id, 'sending', 'failed')
+
+    await callbackDelivery.sendResultCallback(TEST_PLUGIN, batch[1].id, {
+      idempotency_key: 'oralsin-batch-002',
+      status: 'failed',
+      sent_at: null,
+      delivery: null,
+      error: {
+        code: 'adb_send_timeout',
+        message: 'Typing timed out after 120s',
+        retryable: true,
+      },
+    })
+
+    // Both callbacks should have been sent
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+
+    // Verify first callback is 'sent'
+    const [, init1] = mockFetch.mock.calls[0]
+    const body1 = JSON.parse(init1.body as string)
+    expect(body1.status).toBe('sent')
+    expect(body1.idempotency_key).toBe('oralsin-batch-001')
+
+    // Verify second callback is 'failed'
+    const [, init2] = mockFetch.mock.calls[1]
+    const body2 = JSON.parse(init2.body as string)
+    expect(body2.status).toBe('failed')
+    expect(body2.idempotency_key).toBe('oralsin-batch-002')
+    expect(body2.error.code).toBe('adb_send_timeout')
+  })
+
+  it('event bus triggers callback on message:sent event', async () => {
+    registerTestPlugin()
+    mockFetch.mockResolvedValue(new Response('OK', { status: 200 }))
+
+    // Wire up the event bus handler that simulates what the engine does:
+    // on message:sent -> send result callback
+    eventBus.registerHandler(TEST_PLUGIN, 'message:sent', async (data) => {
+      const eventData = data as { id: string; sentAt: string; durationMs: number }
+      await callbackDelivery.sendResultCallback(TEST_PLUGIN, eventData.id, {
+        idempotency_key: 'oralsin-event-001',
+        status: 'sent',
+        sent_at: eventData.sentAt,
+        delivery: {
+          message_id: null,
+          provider: 'adb',
+          sender_phone: '5537999001122',
+          sender_session: 'oralsin-1-4',
+          pair_used: 'MG-Guaxupe',
+          used_fallback: false,
+          elapsed_ms: eventData.durationMs,
+          device_serial: TEST_DEVICE_SERIAL,
+          profile_id: 0,
+          char_count: 50,
+          contact_registered: true,
+          screenshot_url: null,
+          dialogs_dismissed: 1,
+          user_switched: false,
+        },
+        error: null,
+      })
+    })
+
+    // Emit the event (simulates what engine does after successful send)
+    emitter.emit('message:sent', {
+      id: 'msg-event-1',
+      sentAt: '2026-04-13T20:00:00.000Z',
+      durationMs: 9500,
+      deviceSerial: TEST_DEVICE_SERIAL,
+      contactRegistered: true,
+      dialogsDismissed: 1,
+    })
+
+    // Wait for the async dispatch
+    await vi.waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+    })
+
+    // Verify HMAC on the callback
+    const [, init] = mockFetch.mock.calls[0]
+    const headers = init.headers as Record<string, string>
+    const expectedHmac = createHmac('sha256', TEST_HMAC_SECRET)
+      .update(init.body as string)
+      .digest('hex')
+    expect(headers['X-Dispatch-Signature']).toBe(expectedHmac)
+  })
+
+  it('no callback is sent for messages without plugin_name', async () => {
+    // Enqueue a manual message (no plugin)
+    const msg = queue.enqueue({
+      to: '5543991938235',
+      body: 'Manual message',
+      idempotencyKey: 'manual-001',
+    })
+
+    // Process it
+    const dequeued = queue.dequeue(TEST_DEVICE_SERIAL)
+    expect(dequeued).not.toBeNull()
+    queue.updateStatus(dequeued!.id, 'locked', 'sending')
+    queue.updateStatus(dequeued!.id, 'sending', 'sent')
+
+    // Attempt to send callback with null plugin — should no-op
+    await callbackDelivery.sendResultCallback(null as unknown as string, msg.id, {
+      idempotency_key: 'manual-001',
+      status: 'sent',
+      sent_at: new Date().toISOString(),
+      delivery: {
+        message_id: null,
+        provider: 'adb',
+        sender_phone: '5537999001122',
+        sender_session: 'manual',
+        pair_used: 'manual',
+        used_fallback: false,
+        elapsed_ms: 5000,
+        device_serial: TEST_DEVICE_SERIAL,
+        profile_id: 0,
+        char_count: 14,
+        contact_registered: false,
+        screenshot_url: null,
+        dialogs_dismissed: 0,
+        user_switched: false,
+      },
+      error: null,
+    })
+
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it('failed callback is persisted after all retries fail', async () => {
+    vi.useFakeTimers()
+    registerTestPlugin()
+    mockFetch.mockRejectedValue(new Error('ECONNREFUSED'))
+
+    const msg = queue.enqueue({
+      to: '5543991938235',
+      body: 'Will fail callback',
+      idempotencyKey: 'oralsin-fail-001',
+      pluginName: TEST_PLUGIN,
+    })
+
+    const promise = callbackDelivery.sendResultCallback(TEST_PLUGIN, msg.id, {
+      idempotency_key: 'oralsin-fail-001',
+      status: 'sent',
+      sent_at: new Date().toISOString(),
+      delivery: {
+        message_id: null,
+        provider: 'adb',
+        sender_phone: '5537999001122',
+        sender_session: 'oralsin-1-4',
+        pair_used: 'MG-Guaxupe',
+        used_fallback: false,
+        elapsed_ms: 5000,
+        device_serial: TEST_DEVICE_SERIAL,
+        profile_id: 0,
+        char_count: 18,
+        contact_registered: false,
+        screenshot_url: null,
+        dialogs_dismissed: 0,
+        user_switched: false,
+      },
+      error: null,
+    })
+
+    // Advance through all backoff delays: 0 + 5s + 30s + 120s
+    await vi.advanceTimersByTimeAsync(5_000)
+    await vi.advanceTimersByTimeAsync(30_000)
+    await vi.advanceTimersByTimeAsync(120_000)
+    await promise
+
+    // 4 attempts, all failed
+    expect(mockFetch).toHaveBeenCalledTimes(4)
+
+    // Persisted to failed_callbacks
+    const failed = callbackDelivery.listFailedCallbacks()
+    expect(failed).toHaveLength(1)
+    expect(failed[0].plugin_name).toBe(TEST_PLUGIN)
+    expect(failed[0].message_id).toBe(msg.id)
+    expect(failed[0].callback_type).toBe('result')
+    expect(failed[0].attempts).toBe(4)
+    expect(failed[0].last_error).toBe('ECONNREFUSED')
+
+    vi.useRealTimers()
+  })
+
+  it('idempotent enqueue — duplicate key is skipped in batch', async () => {
+    registerTestPlugin()
+
+    // First enqueue
+    queue.enqueue({
+      to: '5543991938235',
+      body: 'Original message',
+      idempotencyKey: 'oralsin-dedup-001',
+      pluginName: TEST_PLUGIN,
+      senderNumber: '5537999001122',
+    })
+
+    // Batch with duplicate + new
+    const result = queue.enqueueBatch([
+      {
+        to: '5543991938235',
+        body: 'Duplicate',
+        idempotencyKey: 'oralsin-dedup-001',
+        pluginName: TEST_PLUGIN,
+        senderNumber: '5537999001122',
+      },
+      {
+        to: '5543991938236',
+        body: 'New message',
+        idempotencyKey: 'oralsin-dedup-002',
+        pluginName: TEST_PLUGIN,
+        senderNumber: '5537999001122',
+      },
+    ])
+
+    expect(result.enqueued).toHaveLength(1)
+    expect(result.enqueued[0].idempotencyKey).toBe('oralsin-dedup-002')
+    expect(result.skipped).toHaveLength(1)
+    expect(result.skipped[0].idempotencyKey).toBe('oralsin-dedup-001')
+    expect(result.skipped[0].reason).toBe('duplicate')
+  })
+})

--- a/packages/core/src/plugins/plugin-event-bus.test.ts
+++ b/packages/core/src/plugins/plugin-event-bus.test.ts
@@ -68,7 +68,6 @@ describe('PluginEventBus', () => {
       const handler = vi.fn<(data: unknown) => Promise<void>>().mockResolvedValue(undefined)
       eventBus.registerHandler('oralsin', 'message:sent', handler)
       registry.disablePlugin('oralsin')
-      eventBus.setPluginEnabled('oralsin', false)
 
       emitter.emit('message:sent', {
         id: 'msg-1',
@@ -148,8 +147,8 @@ describe('PluginEventBus', () => {
       )
       eventBus.registerHandler('oralsin', 'message:sent', slowHandler)
 
-      const errors: unknown[] = []
-      eventBus.onError((err) => errors.push(err))
+      const errors: { pluginName: string; event: string; error: Error }[] = []
+      eventBus.onError((pluginName, event, err) => errors.push({ pluginName, event, error: err }))
 
       emitter.emit('message:sent', {
         id: 'msg-1',
@@ -160,7 +159,9 @@ describe('PluginEventBus', () => {
       await vi.waitFor(
         () => {
           expect(errors).toHaveLength(1)
-          expect((errors[0] as Error).message).toContain('timeout')
+          expect(errors[0].pluginName).toBe('oralsin')
+          expect(errors[0].event).toBe('message:sent')
+          expect(errors[0].error.message).toContain('timeout')
         },
         { timeout: 7000 },
       )

--- a/packages/core/src/plugins/plugin-event-bus.ts
+++ b/packages/core/src/plugins/plugin-event-bus.ts
@@ -2,7 +2,7 @@ import type { DispatchEmitter, DispatchEventName, DispatchEventMap } from '../ev
 import type { PluginRegistry } from './plugin-registry.js'
 
 type PluginHandler = (data: unknown) => Promise<void>
-type ErrorHandler = (err: Error) => void
+type ErrorHandler = (pluginName: string, event: string, err: Error) => void
 
 const HANDLER_TIMEOUT_MS = 5_000
 
@@ -10,7 +10,6 @@ export class PluginEventBus {
   private handlers = new Map<string, Map<DispatchEventName, PluginHandler>>()
   private errorHandlers: ErrorHandler[] = []
   private listeners = new Map<DispatchEventName, (data: unknown) => void>()
-  private pluginEnabled = new Map<string, boolean>()
 
   constructor(
     private registry: PluginRegistry,
@@ -22,7 +21,6 @@ export class PluginEventBus {
       this.handlers.set(pluginName, new Map())
     }
     this.handlers.get(pluginName)!.set(event, handler)
-    this.pluginEnabled.set(pluginName, true)
 
     if (!this.listeners.has(event)) {
       const listener = (data: unknown) => {
@@ -31,10 +29,6 @@ export class PluginEventBus {
       this.emitter.on(event as keyof DispatchEventMap, listener as never)
       this.listeners.set(event, listener)
     }
-  }
-
-  setPluginEnabled(pluginName: string, enabled: boolean): void {
-    this.pluginEnabled.set(pluginName, enabled)
   }
 
   onError(handler: ErrorHandler): void {
@@ -48,7 +42,6 @@ export class PluginEventBus {
     this.handlers.clear()
     this.errorHandlers.length = 0
     this.listeners.clear()
-    this.pluginEnabled.clear()
   }
 
   private async dispatchToPlugins(event: DispatchEventName, data: unknown): Promise<void> {
@@ -58,9 +51,11 @@ export class PluginEventBus {
       const handler = eventHandlers.get(event)
       if (!handler) continue
 
-      if (!this.pluginEnabled.get(pluginName)) continue
+      // R9: Use registry as source of truth instead of local pluginEnabled map
+      const pluginRecord = this.registry.getPlugin(pluginName)
+      if (!pluginRecord || pluginRecord.enabled !== 1) continue
 
-      dispatches.push(this.executeWithTimeout(pluginName, handler, data))
+      dispatches.push(this.executeWithTimeout(pluginName, event, handler, data))
     }
 
     await Promise.allSettled(dispatches)
@@ -68,20 +63,25 @@ export class PluginEventBus {
 
   private async executeWithTimeout(
     pluginName: string,
+    event: DispatchEventName,
     handler: PluginHandler,
     data: unknown,
   ): Promise<void> {
+    // Q1: Fix timer leak — clear timeout in finally
+    let timeoutHandle: ReturnType<typeof setTimeout>
     try {
       const result = handler(data)
       const timeout = new Promise<never>((_, reject) => {
-        setTimeout(() => reject(new Error(`Plugin ${pluginName} handler timeout after ${HANDLER_TIMEOUT_MS}ms`)), HANDLER_TIMEOUT_MS)
+        timeoutHandle = setTimeout(() => reject(new Error(`Plugin ${pluginName} handler timeout after ${HANDLER_TIMEOUT_MS}ms`)), HANDLER_TIMEOUT_MS)
       })
       await Promise.race([result, timeout])
     } catch (err) {
       const error = err instanceof Error ? err : new Error(String(err))
       for (const h of this.errorHandlers) {
-        h(error)
+        h(pluginName, event, error)
       }
+    } finally {
+      clearTimeout(timeoutHandle!)
     }
   }
 }

--- a/packages/core/src/plugins/plugin-loader.test.ts
+++ b/packages/core/src/plugins/plugin-loader.test.ts
@@ -107,14 +107,14 @@ describe('PluginLoader', () => {
       expect(record!.status).toBe('active')
     })
 
-    it('core continues if plugin init() throws', async () => {
+    it('sets error status and re-throws if plugin init() throws', async () => {
       const plugin = makePlugin({
         name: 'broken-plugin',
         init: vi.fn<(ctx: PluginContext) => Promise<void>>().mockRejectedValue(new Error('init crash')),
       })
 
-      // Should not throw
-      await loader.loadPlugin(plugin, 'key-1', 'secret-1')
+      // R2: loadPlugin now re-throws after logging and setting error status
+      await expect(loader.loadPlugin(plugin, 'key-1', 'secret-1')).rejects.toThrow('init crash')
 
       const record = registry.getPlugin('broken-plugin')
       expect(record!.status).toBe('error')

--- a/packages/core/src/plugins/plugin-loader.test.ts
+++ b/packages/core/src/plugins/plugin-loader.test.ts
@@ -219,7 +219,12 @@ describe('PluginLoader', () => {
       const row = db.prepare('SELECT context FROM messages WHERE idempotency_key = ?').get('context-test') as {
         context: string
       }
-      expect(JSON.parse(row.context)).toEqual(context)
+      // Decision #17: patient_id and template_id are merged into context from patient/message params
+      expect(JSON.parse(row.context)).toEqual({
+        ...context,
+        patient_id: 'patient-uuid-1',
+        template_id: 'overdue_reminder_v2',
+      })
     })
 
     it('merges send_options with defaults (max_retries and priority only)', async () => {

--- a/packages/core/src/plugins/plugin-loader.test.ts
+++ b/packages/core/src/plugins/plugin-loader.test.ts
@@ -247,7 +247,7 @@ describe('PluginLoader', () => {
       expect(row.max_retries).toBe(5)
     })
 
-    it('rejects duplicate idempotency_key', async () => {
+    it('skips duplicate idempotency_key', async () => {
       const plugin = makePlugin({ name: 'oralsin' })
       let capturedCtx: PluginContext | null = null
       ;(plugin.init as ReturnType<typeof vi.fn>).mockImplementation(async (ctx: PluginContext) => {
@@ -256,9 +256,11 @@ describe('PluginLoader', () => {
 
       await loader.loadPlugin(plugin, 'key-1', 'secret-1')
 
-      capturedCtx!.enqueue([makeEnqueueParams({ idempotencyKey: 'dup-key' })])
+      const first = capturedCtx!.enqueue([makeEnqueueParams({ idempotencyKey: 'dup-key' })])
+      expect(first).toHaveLength(1)
 
-      expect(() => capturedCtx!.enqueue([makeEnqueueParams({ idempotencyKey: 'dup-key' })])).toThrow()
+      const second = capturedCtx!.enqueue([makeEnqueueParams({ idempotencyKey: 'dup-key' })])
+      expect(second).toHaveLength(0)
     })
   })
 

--- a/packages/core/src/plugins/plugin-loader.ts
+++ b/packages/core/src/plugins/plugin-loader.ts
@@ -73,11 +73,20 @@ export class PluginLoader {
 
     const ctx = this.createContext(plugin.name)
 
+    // Q3: validate pluginName against registry
+    const registered = this.registry.getPlugin(plugin.name)
+    if (!registered) throw new Error(`Plugin ${plugin.name} not registered after upsert`)
+
     try {
       await plugin.init(ctx)
       this.loadedPlugins.set(plugin.name, plugin)
-    } catch {
+    } catch (err) {
+      // R2: log + re-throw on init error
       this.registry.setPluginStatus(plugin.name, 'error')
+      this.loggerFactory.child({ plugin: plugin.name }).error('Plugin init failed', {
+        err: err instanceof Error ? err.message : String(err),
+      })
+      throw err
     }
   }
 
@@ -90,8 +99,15 @@ export class PluginLoader {
   }
 
   async destroyAll(): Promise<void> {
-    for (const [name] of this.loadedPlugins) {
-      await this.unloadPlugin(name)
+    for (const [name, plugin] of this.loadedPlugins) {
+      try {
+        await plugin.destroy()
+        this.loadedPlugins.delete(name)
+      } catch (err) {
+        this.loggerFactory.child({ plugin: name }).warn('Plugin destroy failed', {
+          err: err instanceof Error ? err.message : String(err),
+        })
+      }
     }
   }
 

--- a/packages/core/src/plugins/plugin-loader.ts
+++ b/packages/core/src/plugins/plugin-loader.ts
@@ -135,11 +135,11 @@ export class PluginLoader {
             idempotencyKey: m.idempotencyKey,
             priority: PRIORITY_MAP[m.sendOptions?.priority ?? 'normal'] ?? 5,
             // P10: Only use resolvedSenderPhone — no senders[0] fallback
-            senderNumber: m.resolvedSenderPhone ?? null,
+            senderNumber: m.resolvedSenderPhone ?? undefined,
             pluginName,
             correlationId: m.correlationId ?? undefined,
             sendersConfig: JSON.stringify(m.senders),
-            context: hasContext ? JSON.stringify(mergedContext) : null,
+            context: hasContext ? JSON.stringify(mergedContext) : undefined,
             maxRetries: m.sendOptions?.maxRetries ?? 3,
             contactName: m.patient.name ?? undefined,
           }

--- a/packages/core/src/plugins/plugin-loader.ts
+++ b/packages/core/src/plugins/plugin-loader.ts
@@ -120,19 +120,30 @@ export class PluginLoader {
 
     return {
       enqueue: (msgs: PluginEnqueueParams[]): PluginMessage[] => {
-        const params = msgs.map((m) => ({
-          to: m.patient.phone,
-          body: m.message.text,
-          idempotencyKey: m.idempotencyKey,
-          priority: PRIORITY_MAP[m.sendOptions?.priority ?? 'normal'] ?? 5,
-          senderNumber: m.resolvedSenderPhone ?? m.senders[0]?.phone ?? null,
-          pluginName,
-          correlationId: m.correlationId ?? undefined,
-          sendersConfig: JSON.stringify(m.senders),
-          context: m.context ? JSON.stringify(m.context) : null,
-          maxRetries: m.sendOptions?.maxRetries ?? 3,
-          contactName: m.patient.name ?? undefined,
-        }))
+        const params = msgs.map((m) => {
+          // P1/Decision #17: Merge patientId and templateId into context
+          const mergedContext = {
+            ...m.context,
+            ...(m.patient.patientId ? { patient_id: m.patient.patientId } : {}),
+            ...(m.message.templateId ? { template_id: m.message.templateId } : {}),
+          }
+          const hasContext = Object.keys(mergedContext).length > 0
+
+          return {
+            to: m.patient.phone,
+            body: m.message.text,
+            idempotencyKey: m.idempotencyKey,
+            priority: PRIORITY_MAP[m.sendOptions?.priority ?? 'normal'] ?? 5,
+            // P10: Only use resolvedSenderPhone — no senders[0] fallback
+            senderNumber: m.resolvedSenderPhone ?? null,
+            pluginName,
+            correlationId: m.correlationId ?? undefined,
+            sendersConfig: JSON.stringify(m.senders),
+            context: hasContext ? JSON.stringify(mergedContext) : null,
+            maxRetries: m.sendOptions?.maxRetries ?? 3,
+            contactName: m.patient.name ?? undefined,
+          }
+        })
 
         // D5: saveContact is now inside enqueueBatch transaction via contactName param
         const { enqueued: messages } = this.queue.enqueueBatch(params)

--- a/packages/core/src/plugins/plugin-loader.ts
+++ b/packages/core/src/plugins/plugin-loader.ts
@@ -115,16 +115,11 @@ export class PluginLoader {
           sendersConfig: JSON.stringify(m.senders),
           context: m.context ? JSON.stringify(m.context) : null,
           maxRetries: m.sendOptions?.maxRetries ?? 3,
+          contactName: m.patient.name ?? undefined,
         }))
 
-        // Save patient contacts with real names for ADB send
-        for (const m of msgs) {
-          if (m.patient.phone && m.patient.name) {
-            this.queue.saveContact(m.patient.phone, m.patient.name)
-          }
-        }
-
-        const messages = this.queue.enqueueBatch(params)
+        // D5: saveContact is now inside enqueueBatch transaction via contactName param
+        const { enqueued: messages } = this.queue.enqueueBatch(params)
 
         return messages.map((msg) => ({
           id: msg.id,

--- a/packages/core/src/plugins/plugin-registry.test.ts
+++ b/packages/core/src/plugins/plugin-registry.test.ts
@@ -260,4 +260,28 @@ describe('PluginRegistry', () => {
       expect(plugin).toBeNull()
     })
   })
+
+  describe('schema hardening (Batch 1)', () => {
+    it('plugins timestamps use ISO 8601 with milliseconds', () => {
+      registry.register({
+        name: 'oralsin',
+        version: '1.0.0',
+        webhookUrl: 'https://oralsin.example.com/webhook',
+        apiKey: 'key-1',
+        hmacSecret: 'secret-1',
+        events: ['message:sent'],
+      })
+      const plugin = registry.getPlugin('oralsin')
+      expect(plugin!.created_at).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/)
+      expect(plugin!.updated_at).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/)
+    })
+
+    it('idx_failed_callbacks_retry index exists', () => {
+      const indexes = db.prepare(
+        "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='failed_callbacks'",
+      ).all() as { name: string }[]
+      const names = indexes.map(i => i.name)
+      expect(names).toContain('idx_failed_callbacks_retry')
+    })
+  })
 })

--- a/packages/core/src/plugins/plugin-registry.ts
+++ b/packages/core/src/plugins/plugin-registry.ts
@@ -1,6 +1,6 @@
 import type Database from 'better-sqlite3'
 import { nanoid } from 'nanoid'
-import type { PluginRecord } from './types.js'
+import type { PluginRecord, PluginStatus } from './types.js'
 
 export interface RegisterPluginParams {
   name: string
@@ -75,6 +75,8 @@ export class PluginRegistry {
       ON CONFLICT(name) DO UPDATE SET
         version = excluded.version,
         webhook_url = excluded.webhook_url,
+        api_key = excluded.api_key,
+        hmac_secret = excluded.hmac_secret,
         events = excluded.events,
         updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
     `)
@@ -151,7 +153,7 @@ export class PluginRegistry {
     return newKey
   }
 
-  setPluginStatus(name: string, status: string): void {
+  setPluginStatus(name: string, status: PluginStatus): void {
     this.stmtSetStatus.run(status, name)
   }
 

--- a/packages/core/src/plugins/plugin-registry.ts
+++ b/packages/core/src/plugins/plugin-registry.ts
@@ -43,8 +43,8 @@ export class PluginRegistry {
         events TEXT NOT NULL DEFAULT '[]',
         enabled INTEGER NOT NULL DEFAULT 1,
         status TEXT NOT NULL DEFAULT 'active',
-        created_at TEXT NOT NULL DEFAULT (datetime('now')),
-        updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+        created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+        updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
       );
 
       CREATE TABLE IF NOT EXISTS failed_callbacks (
@@ -56,11 +56,13 @@ export class PluginRegistry {
         webhook_url TEXT NOT NULL,
         attempts INTEGER NOT NULL DEFAULT 0,
         last_error TEXT NOT NULL DEFAULT '',
-        created_at TEXT NOT NULL DEFAULT (datetime('now')),
-        last_attempt_at TEXT NOT NULL DEFAULT (datetime('now'))
+        created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+        last_attempt_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
       );
       CREATE INDEX IF NOT EXISTS idx_failed_callbacks_plugin
         ON failed_callbacks(plugin_name);
+      CREATE INDEX IF NOT EXISTS idx_failed_callbacks_retry
+        ON failed_callbacks(attempts, created_at);
     `)
 
     this.prepareStatements()
@@ -74,28 +76,28 @@ export class PluginRegistry {
         version = excluded.version,
         webhook_url = excluded.webhook_url,
         events = excluded.events,
-        updated_at = datetime('now')
+        updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
     `)
     this.stmtGetPlugin = this.db.prepare('SELECT * FROM plugins WHERE name = ?')
     this.stmtListPlugins = this.db.prepare('SELECT * FROM plugins ORDER BY name')
     this.stmtUpdateWebhookUrl = this.db.prepare(
-      "UPDATE plugins SET webhook_url = ?, updated_at = datetime('now') WHERE name = ?",
+      "UPDATE plugins SET webhook_url = ?, updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now') WHERE name = ?",
     )
     this.stmtUpdateEvents = this.db.prepare(
-      "UPDATE plugins SET events = ?, updated_at = datetime('now') WHERE name = ?",
+      "UPDATE plugins SET events = ?, updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now') WHERE name = ?",
     )
     this.stmtDisable = this.db.prepare(
-      "UPDATE plugins SET enabled = 0, status = 'disabled', updated_at = datetime('now') WHERE name = ?",
+      "UPDATE plugins SET enabled = 0, status = 'disabled', updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now') WHERE name = ?",
     )
     this.stmtEnable = this.db.prepare(
-      "UPDATE plugins SET enabled = 1, status = 'active', updated_at = datetime('now') WHERE name = ?",
+      "UPDATE plugins SET enabled = 1, status = 'active', updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now') WHERE name = ?",
     )
     this.stmtDelete = this.db.prepare('DELETE FROM plugins WHERE name = ?')
     this.stmtRotateApiKey = this.db.prepare(
-      "UPDATE plugins SET api_key = ?, updated_at = datetime('now') WHERE name = ?",
+      "UPDATE plugins SET api_key = ?, updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now') WHERE name = ?",
     )
     this.stmtSetStatus = this.db.prepare(
-      "UPDATE plugins SET status = ?, updated_at = datetime('now') WHERE name = ?",
+      "UPDATE plugins SET status = ?, updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now') WHERE name = ?",
     )
     this.stmtGetByApiKey = this.db.prepare(
       'SELECT * FROM plugins WHERE api_key = ? AND enabled = 1',

--- a/packages/core/src/plugins/types.ts
+++ b/packages/core/src/plugins/types.ts
@@ -42,7 +42,7 @@ export interface PluginLogger {
 }
 
 export type PluginStatus = 'active' | 'error' | 'disabled'
-export type CallbackType = 'result' | 'ack' | 'response'
+export type CallbackType = 'result' | 'ack' | 'response' | 'interim_failure' | 'expired'
 
 // ── Plugin Record (SQLite row) ──
 
@@ -155,8 +155,30 @@ export interface CallbackError {
 
 export interface FallbackReason {
   original_error: string
+  original_message?: string
   original_session: string
   quarantined: boolean
+}
+
+export interface InterimFailureCallback {
+  event: 'interim_failure'
+  idempotency_key: string
+  correlation_id?: string
+  status: 'interim_failed'
+  error: { code: string; message: string; retryable: boolean }
+  failed_sender: { phone: string; session: string; pair: string } | null
+  next_sender: { phone: string; session: string; pair: string; role: string } | null
+  attempt: number
+  context?: Record<string, unknown>
+}
+
+export interface ExpiredCallback {
+  event: 'expired'
+  idempotency_key: string
+  correlation_id?: string
+  status: 'expired'
+  error: { code: 'ttl_expired'; message: string; retryable: false }
+  context?: Record<string, unknown>
 }
 
 export interface AckCallback {

--- a/packages/core/src/queue/message-queue-pagination.test.ts
+++ b/packages/core/src/queue/message-queue-pagination.test.ts
@@ -26,7 +26,16 @@ describe('MessageQueue.listPaginated', () => {
         pluginName: overrides.pluginName,
       })
       if (overrides.status && overrides.status !== 'queued') {
-        queue.updateStatus(msg.id, overrides.status as 'sent' | 'failed')
+        // Walk through valid transitions: queued → locked → sending → target
+        queue.dequeue('seed-device')
+        queue.updateStatus(msg.id, 'locked', 'sending')
+        if (overrides.status === 'sent') {
+          queue.updateStatus(msg.id, 'sending', 'sent')
+        } else if (overrides.status === 'failed') {
+          queue.updateStatus(msg.id, 'sending', 'failed')
+        } else if (overrides.status === 'permanently_failed') {
+          queue.updateStatus(msg.id, 'sending', 'permanently_failed')
+        }
       }
     }
   }
@@ -164,7 +173,9 @@ describe('MessageQueue.listPaginated', () => {
           idempotencyKey: `match-${i}`,
           pluginName: 'oralsin',
         })
-        queue.updateStatus(msg.id, 'sent')
+        queue.dequeue('seed-device')
+        queue.updateStatus(msg.id, 'locked', 'sending')
+        queue.updateStatus(msg.id, 'sending', 'sent')
       }
       // 2 sent oralsin messages with different phone
       for (let i = 0; i < 2; i++) {
@@ -174,7 +185,9 @@ describe('MessageQueue.listPaginated', () => {
           idempotencyKey: `nomatch-${i}`,
           pluginName: 'oralsin',
         })
-        queue.updateStatus(msg.id, 'sent')
+        queue.dequeue('seed-device')
+        queue.updateStatus(msg.id, 'locked', 'sending')
+        queue.updateStatus(msg.id, 'sending', 'sent')
       }
       // 1 queued oralsin message with target phone
       queue.enqueue({

--- a/packages/core/src/queue/message-queue.test.ts
+++ b/packages/core/src/queue/message-queue.test.ts
@@ -315,4 +315,71 @@ describe('MessageQueue', () => {
       expect(found).toBeNull()
     })
   })
+
+  describe('schema hardening (Batch 1)', () => {
+    it('PRAGMA busy_timeout can be set to 5000', () => {
+      db.pragma('busy_timeout = 5000')
+      const result = db.pragma('busy_timeout') as unknown[]
+      // better-sqlite3 returns [{busy_timeout: N}] — extract the value regardless of format
+      const value = typeof result[0] === 'object' && result[0] !== null
+        ? Object.values(result[0] as Record<string, unknown>)[0]
+        : result[0]
+      expect(value).toBe(5000)
+    })
+
+    it('idx_messages_plugin_name index exists', () => {
+      const indexes = db.prepare(
+        "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='messages'",
+      ).all() as { name: string }[]
+      const names = indexes.map(i => i.name)
+      expect(names).toContain('idx_messages_plugin_name')
+    })
+
+    it('messages.sent_at column exists and defaults to null', () => {
+      const msg = queue.enqueue({ to: '111', body: 'Test', idempotencyKey: 'sat-1' })
+      expect(msg.sentAt).toBeNull()
+    })
+
+    it('messages.sent_at is set when status transitions to sent', () => {
+      const msg = queue.enqueue({ to: '111', body: 'Test', idempotencyKey: 'sat-2' })
+      queue.dequeue('device-001')
+      queue.updateStatus(msg.id, 'sending')
+      const sent = queue.updateStatus(msg.id, 'sent')
+      expect(sent.sentAt).not.toBeNull()
+      expect(sent.sentAt).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+    })
+
+    it('messages.priority CHECK constraint rejects out-of-range values', () => {
+      expect(() =>
+        queue.enqueue({ to: '111', body: 'Test', idempotencyKey: 'pri-0', priority: 0 }),
+      ).toThrow()
+      expect(() =>
+        queue.enqueue({ to: '111', body: 'Test', idempotencyKey: 'pri-11', priority: 11 }),
+      ).toThrow()
+    })
+
+    it('messages.priority accepts values 1-10', () => {
+      const low = queue.enqueue({ to: '111', body: 'Low', idempotencyKey: 'pri-1', priority: 1 })
+      const high = queue.enqueue({ to: '111', body: 'High', idempotencyKey: 'pri-10', priority: 10 })
+      expect(low.priority).toBe(1)
+      expect(high.priority).toBe(10)
+    })
+
+    it('timestamps use ISO 8601 with milliseconds', () => {
+      const msg = queue.enqueue({ to: '111', body: 'ISO', idempotencyKey: 'iso-1' })
+      // strftime('%Y-%m-%dT%H:%M:%fZ') produces e.g. 2026-04-13T16:00:00.123Z
+      expect(msg.createdAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/)
+    })
+
+    it('getQueueStats works with pluginName filter', () => {
+      queue.enqueue({ to: '111', body: 'A', idempotencyKey: 'gs-1', pluginName: 'oralsin' })
+      queue.enqueue({ to: '222', body: 'B', idempotencyKey: 'gs-2', pluginName: 'other' })
+
+      const allStats = queue.getQueueStats()
+      expect(allStats.pending).toBe(2)
+
+      const oralsinStats = queue.getQueueStats('oralsin')
+      expect(oralsinStats.pending).toBe(1)
+    })
+  })
 })

--- a/packages/core/src/queue/message-queue.test.ts
+++ b/packages/core/src/queue/message-queue.test.ts
@@ -237,25 +237,25 @@ describe('MessageQueue', () => {
       queue.enqueue({ to: '111', body: 'Hello', idempotencyKey: 'k1' })
       const locked = queue.dequeue('device-001')
 
-      const sending = queue.updateStatus(locked!.id, 'sending')
+      const sending = queue.updateStatus(locked!.id, 'locked', 'sending')
       expect(sending.status).toBe('sending')
     })
 
     it('transitions sending → sent', () => {
       queue.enqueue({ to: '111', body: 'Hello', idempotencyKey: 'k1' })
       const locked = queue.dequeue('device-001')
-      queue.updateStatus(locked!.id, 'sending')
+      queue.updateStatus(locked!.id, 'locked', 'sending')
 
-      const sent = queue.updateStatus(locked!.id, 'sent')
+      const sent = queue.updateStatus(locked!.id, 'sending', 'sent')
       expect(sent.status).toBe('sent')
     })
 
     it('transitions sending → failed', () => {
       queue.enqueue({ to: '111', body: 'Hello', idempotencyKey: 'k1' })
       const locked = queue.dequeue('device-001')
-      queue.updateStatus(locked!.id, 'sending')
+      queue.updateStatus(locked!.id, 'locked', 'sending')
 
-      const failed = queue.updateStatus(locked!.id, 'failed')
+      const failed = queue.updateStatus(locked!.id, 'sending', 'failed')
       expect(failed.status).toBe('failed')
     })
 
@@ -268,12 +268,12 @@ describe('MessageQueue', () => {
         "UPDATE messages SET updated_at = '2000-01-01T00:00:00.000Z' WHERE id = ?",
       ).run(locked!.id)
 
-      const sending = queue.updateStatus(locked!.id, 'sending')
+      const sending = queue.updateStatus(locked!.id, 'locked', 'sending')
       expect(sending.updatedAt).not.toBe('2000-01-01T00:00:00.000Z')
     })
 
     it('throws for non-existent message id', () => {
-      expect(() => queue.updateStatus('nonexistent', 'sending')).toThrow()
+      expect(() => queue.updateStatus('nonexistent', 'locked', 'sending')).toThrow()
     })
   })
 
@@ -343,8 +343,8 @@ describe('MessageQueue', () => {
     it('messages.sent_at is set when status transitions to sent', () => {
       const msg = queue.enqueue({ to: '111', body: 'Test', idempotencyKey: 'sat-2' })
       queue.dequeue('device-001')
-      queue.updateStatus(msg.id, 'sending')
-      const sent = queue.updateStatus(msg.id, 'sent')
+      queue.updateStatus(msg.id, 'locked', 'sending')
+      const sent = queue.updateStatus(msg.id, 'sending', 'sent')
       expect(sent.sentAt).not.toBeNull()
       expect(sent.sentAt).toMatch(/^\d{4}-\d{2}-\d{2}T/)
     })
@@ -380,6 +380,108 @@ describe('MessageQueue', () => {
 
       const oralsinStats = queue.getQueueStats('oralsin')
       expect(oralsinStats.pending).toBe(1)
+    })
+  })
+
+  describe('state machine (Batch 2)', () => {
+    it('rejects invalid transition queued → sent', () => {
+      const msg = queue.enqueue({ to: '111', body: 'Test', idempotencyKey: 'sm-1' })
+      expect(() => queue.updateStatus(msg.id, 'queued', 'sent')).toThrow('Invalid state transition')
+    })
+
+    it('accepts valid transition locked → sending', () => {
+      queue.enqueue({ to: '111', body: 'Test', idempotencyKey: 'sm-2' })
+      const locked = queue.dequeue('device-001')
+      const sending = queue.updateStatus(locked!.id, 'locked', 'sending')
+      expect(sending.status).toBe('sending')
+    })
+
+    it('CAS fails when status does not match from', () => {
+      const msg = queue.enqueue({ to: '111', body: 'Test', idempotencyKey: 'sm-3' })
+      // Message is in 'queued', but we pass 'locked' as from
+      expect(() => queue.updateStatus(msg.id, 'locked', 'sending')).toThrow('status mismatch')
+    })
+
+    it('markPermanentlyFailed sets real attempts count', () => {
+      const msg = queue.enqueue({ to: '111', body: 'Test', idempotencyKey: 'sm-4' })
+      queue.dequeue('device-001')
+      queue.updateStatus(msg.id, 'locked', 'sending')
+      const pf = queue.markPermanentlyFailed(msg.id, 3)
+      expect(pf.status).toBe('permanently_failed')
+      expect(pf.attempts).toBe(3)
+    })
+
+    it('requeueForRetry increments attempts and resets lock', () => {
+      const msg = queue.enqueue({ to: '111', body: 'Test', idempotencyKey: 'sm-5' })
+      queue.dequeue('device-001')
+      queue.updateStatus(msg.id, 'locked', 'sending')
+      const requeued = queue.requeueForRetry(msg.id)
+      expect(requeued.status).toBe('queued')
+      expect(requeued.attempts).toBe(1)
+      expect(requeued.lockedBy).toBeNull()
+    })
+  })
+
+  describe('enqueueBatch partial-failure (Batch 2)', () => {
+    it('skips blacklisted numbers per-item', () => {
+      // Add to blacklist
+      db.prepare("INSERT INTO blacklist (phone_number, reason) VALUES ('111', 'spam')").run()
+
+      const result = queue.enqueueBatch([
+        { to: '111', body: 'Blocked', idempotencyKey: 'bf-1' },
+        { to: '222', body: 'OK', idempotencyKey: 'bf-2' },
+      ])
+
+      expect(result.enqueued).toHaveLength(1)
+      expect(result.enqueued[0].to).toBe('222')
+      expect(result.skipped).toHaveLength(1)
+      expect(result.skipped[0].reason).toBe('blacklisted')
+    })
+
+    it('skips duplicate idempotency_key with ON CONFLICT DO NOTHING', () => {
+      queue.enqueue({ to: '111', body: 'First', idempotencyKey: 'dup-1' })
+
+      const result = queue.enqueueBatch([
+        { to: '222', body: 'Dup', idempotencyKey: 'dup-1' },
+        { to: '333', body: 'New', idempotencyKey: 'dup-2' },
+      ])
+
+      expect(result.enqueued).toHaveLength(1)
+      expect(result.enqueued[0].to).toBe('333')
+      expect(result.skipped).toHaveLength(1)
+      expect(result.skipped[0].reason).toBe('duplicate')
+    })
+
+    it('saves contacts inside the batch transaction', () => {
+      const result = queue.enqueueBatch([
+        { to: '111', body: 'Hi', idempotencyKey: 'ct-1', contactName: 'Alice' },
+      ])
+
+      expect(result.enqueued).toHaveLength(1)
+      expect(queue.getContactName('111')).toBe('Alice')
+    })
+
+    it('maxRetries=3 produces exactly 3 send attempts (via requeueForRetry)', () => {
+      const msg = queue.enqueue({ to: '111', body: 'Test', idempotencyKey: 'mr-1', maxRetries: 3 })
+      expect(msg.maxRetries).toBe(3)
+
+      // Simulate 3 failed attempts
+      for (let i = 0; i < 3; i++) {
+        const locked = queue.dequeue('device-001')
+        expect(locked).not.toBeNull()
+        queue.updateStatus(locked!.id, 'locked', 'sending')
+
+        if (i < 2) {
+          // Requeue for retry
+          const requeued = queue.requeueForRetry(locked!.id)
+          expect(requeued.attempts).toBe(i + 1)
+        } else {
+          // Last attempt — mark permanently failed with real attempts
+          const pf = queue.markPermanentlyFailed(locked!.id, i + 1)
+          expect(pf.attempts).toBe(3)
+          expect(pf.status).toBe('permanently_failed')
+        }
+      }
     })
   })
 })

--- a/packages/core/src/queue/message-queue.ts
+++ b/packages/core/src/queue/message-queue.ts
@@ -330,7 +330,8 @@ export class MessageQueue {
   }
 
   cleanStaleLocks(): number {
-    const result = this.db.prepare(`
+    // R1: Recover locked > 120s
+    const lockedResult = this.db.prepare(`
       UPDATE messages
       SET status = 'queued',
           locked_by = NULL,
@@ -339,7 +340,33 @@ export class MessageQueue {
       WHERE status = 'locked'
         AND locked_at < strftime('%Y-%m-%dT%H:%M:%fZ', 'now', '-120 seconds')
     `).run()
-    return result.changes
+
+    // R1/Decision #9: Recover sending > 300s (2x worst case send timeout)
+    const sendingResult = this.db.prepare(`
+      UPDATE messages
+      SET status = 'queued',
+          locked_by = NULL,
+          locked_at = NULL,
+          updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+      WHERE status = 'sending'
+        AND updated_at < strftime('%Y-%m-%dT%H:%M:%fZ', 'now', '-300 seconds')
+    `).run()
+
+    return lockedResult.changes + sendingResult.changes
+  }
+
+  /** Decision #8: Expire waiting_device messages older than TTL */
+  expireWaitingDeviceMessages(ttlMs: number): Message[] {
+    const ttlSeconds = Math.floor(ttlMs / 1000)
+    const rows = this.db.prepare(`
+      UPDATE messages
+      SET status = 'permanently_failed',
+          updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+      WHERE status = 'waiting_device'
+        AND updated_at < strftime('%Y-%m-%dT%H:%M:%fZ', 'now', '-' || ? || ' seconds')
+      RETURNING *
+    `).all(ttlSeconds) as Record<string, unknown>[]
+    return rows.map(row => this.rowToMessage(row))
   }
 
   list(status?: MessageStatus, limit = 50): Message[] {

--- a/packages/core/src/queue/message-queue.ts
+++ b/packages/core/src/queue/message-queue.ts
@@ -12,7 +12,7 @@ export class MessageQueue {
         to_number TEXT NOT NULL,
         body TEXT NOT NULL,
         idempotency_key TEXT NOT NULL UNIQUE,
-        priority INTEGER NOT NULL DEFAULT 5,
+        priority INTEGER NOT NULL DEFAULT 5 CHECK (priority BETWEEN 1 AND 10),
         sender_number TEXT,
         status TEXT NOT NULL DEFAULT 'queued',
         attempts INTEGER NOT NULL DEFAULT 0,
@@ -26,6 +26,7 @@ export class MessageQueue {
         max_retries INTEGER NOT NULL DEFAULT 3,
         fallback_used INTEGER NOT NULL DEFAULT 0,
         fallback_provider TEXT,
+        sent_at TEXT DEFAULT NULL,
         created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
         updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
       );
@@ -35,6 +36,8 @@ export class MessageQueue {
         ON messages(sender_number);
       CREATE INDEX IF NOT EXISTS idx_messages_sender_daily
         ON messages(sender_number, status, updated_at);
+      CREATE INDEX IF NOT EXISTS idx_messages_plugin_name
+        ON messages(plugin_name, status, created_at);
 
       CREATE TABLE IF NOT EXISTS contacts (
         phone TEXT PRIMARY KEY,
@@ -103,6 +106,11 @@ export class MessageQueue {
       this.db.exec("ALTER TABLE messages ADD COLUMN media_url TEXT")
       this.db.exec("ALTER TABLE messages ADD COLUMN media_type TEXT")
       this.db.exec("ALTER TABLE messages ADD COLUMN media_caption TEXT")
+    }
+
+    // Migration: add sent_at column if not present
+    if (!cols.some(c => c.name === 'sent_at')) {
+      this.db.exec("ALTER TABLE messages ADD COLUMN sent_at TEXT DEFAULT NULL")
     }
   }
 
@@ -191,6 +199,9 @@ export class MessageQueue {
   }
 
   getQueueStats(pluginName?: string): { pending: number; processing: number; failedLastHour: number; oldestPendingAgeSeconds: number | null } {
+    const whereClause = pluginName ? 'WHERE plugin_name = ?' : ''
+    const binds = pluginName ? [pluginName] : []
+
     const row = this.db.prepare(`
       SELECT
         COUNT(*) FILTER (WHERE status = 'queued') AS pending,
@@ -199,8 +210,8 @@ export class MessageQueue {
           AND updated_at > strftime('%Y-%m-%dT%H:%M:%fZ', 'now', '-1 hour')) AS failed_last_hour,
         MIN(CASE WHEN status = 'queued' THEN created_at END) AS oldest_queued
       FROM messages
-      WHERE (? IS NULL OR plugin_name = ?)
-    `).get(pluginName ?? null, pluginName ?? null) as {
+      ${whereClause}
+    `).get(...binds) as {
       pending: number
       processing: number
       failed_last_hour: number
@@ -242,9 +253,10 @@ export class MessageQueue {
   }
 
   updateStatus(id: string, status: MessageStatus): Message {
+    const sentAtClause = status === 'sent' ? ", sent_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')" : ''
     const row = this.db.prepare(`
       UPDATE messages
-      SET status = ?, updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+      SET status = ?, updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')${sentAtClause}
       WHERE id = ?
       RETURNING *
     `).get(status, id) as Record<string, unknown> | undefined
@@ -398,6 +410,7 @@ export class MessageQueue {
       context: (row.context as string) ?? null,
       wahaMessageId: (row.waha_message_id as string) ?? null,
       maxRetries: (row.max_retries as number) ?? 3,
+      sentAt: (row.sent_at as string) ?? null,
       fallbackUsed: (row.fallback_used as number) ?? 0,
       fallbackProvider: (row.fallback_provider as string) ?? null,
       screenshotPath: (row.screenshot_path as string) ?? null,

--- a/packages/core/src/queue/message-queue.ts
+++ b/packages/core/src/queue/message-queue.ts
@@ -1,6 +1,7 @@
 import type Database from 'better-sqlite3'
 import { nanoid } from 'nanoid'
-import type { EnqueueParams, Message, MessageStatus, PaginatedFilters, PaginatedResult } from './types.js'
+import type { EnqueueParams, Message, MessageStatus, PaginatedFilters, PaginatedResult, BatchResult, SkippedItem } from './types.js'
+import { VALID_TRANSITIONS } from './types.js'
 
 export class MessageQueue {
   constructor(private db: Database.Database) {}
@@ -149,21 +150,31 @@ export class MessageQueue {
     return this.rowToMessage(row)
   }
 
-  enqueueBatch(paramsList: EnqueueParams[]): Message[] {
+  enqueueBatch(paramsList: EnqueueParams[]): BatchResult {
     const insert = this.db.prepare(`
-      INSERT INTO messages (id, to_number, body, idempotency_key, priority, sender_number,
+      INSERT OR IGNORE INTO messages (id, to_number, body, idempotency_key, priority, sender_number,
                             plugin_name, correlation_id, senders_config, context, max_retries,
                             media_url, media_type, media_caption)
       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-      RETURNING *
     `)
+    const select = this.db.prepare('SELECT * FROM messages WHERE id = ?')
+    const saveContactStmt = this.db.prepare(
+      'INSERT INTO contacts (phone, name) VALUES (?, ?) ON CONFLICT(phone) DO UPDATE SET name = excluded.name',
+    )
+
     const txn = this.db.transaction((list: EnqueueParams[]) => {
-      return list.map((params) => {
+      const enqueued: Message[] = []
+      const skipped: SkippedItem[] = []
+
+      for (const params of list) {
+        // Skip blacklisted numbers per-item
         if (this.isBlacklisted(params.to)) {
-          throw new Error(`Phone ${params.to} is blacklisted — message rejected`)
+          skipped.push({ idempotencyKey: params.idempotencyKey, reason: 'blacklisted', to: params.to })
+          continue
         }
+
         const id = nanoid()
-        const row = insert.get(
+        const result = insert.run(
           id,
           params.to,
           params.body,
@@ -178,9 +189,24 @@ export class MessageQueue {
           params.mediaUrl ?? null,
           params.mediaType ?? null,
           params.mediaCaption ?? null,
-        ) as Record<string, unknown>
-        return this.rowToMessage(row)
-      })
+        )
+
+        if (result.changes === 0) {
+          // ON CONFLICT DO NOTHING — duplicate idempotency_key
+          skipped.push({ idempotencyKey: params.idempotencyKey, reason: 'duplicate' })
+          continue
+        }
+
+        const row = select.get(id) as Record<string, unknown>
+        enqueued.push(this.rowToMessage(row))
+
+        // D5: saveContact inside the batch transaction
+        if (params.contactName) {
+          saveContactStmt.run(params.to, params.contactName)
+        }
+      }
+
+      return { enqueued, skipped }
     })
     return txn(paramsList)
   }
@@ -252,17 +278,20 @@ export class MessageQueue {
     return row ? this.rowToMessage(row) : null
   }
 
-  updateStatus(id: string, status: MessageStatus): Message {
-    const sentAtClause = status === 'sent' ? ", sent_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')" : ''
+  updateStatus(id: string, from: MessageStatus, to: MessageStatus): Message {
+    if (!VALID_TRANSITIONS[from]?.includes(to)) {
+      throw new Error(`Invalid state transition: ${from} → ${to}`)
+    }
+    const sentAtClause = to === 'sent' ? ", sent_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')" : ''
     const row = this.db.prepare(`
       UPDATE messages
       SET status = ?, updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')${sentAtClause}
-      WHERE id = ?
+      WHERE id = ? AND status = ?
       RETURNING *
-    `).get(status, id) as Record<string, unknown> | undefined
+    `).get(to, id, from) as Record<string, unknown> | undefined
 
     if (!row) {
-      throw new Error(`Message not found: ${id}`)
+      throw new Error(`Message not found or status mismatch (expected ${from}): ${id}`)
     }
     return this.rowToMessage(row)
   }
@@ -275,16 +304,29 @@ export class MessageQueue {
           locked_by = NULL,
           locked_at = NULL,
           updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
-      WHERE id = ?
+      WHERE id = ? AND status IN ('sending', 'failed', 'locked')
       RETURNING *
     `).get(id) as Record<string, unknown> | undefined
 
-    if (!row) throw new Error(`Message not found: ${id}`)
+    if (!row) throw new Error(`Message not found or invalid state for requeue: ${id}`)
     return this.rowToMessage(row)
   }
 
-  markPermanentlyFailed(id: string): Message {
-    return this.updateStatus(id, 'permanently_failed')
+  markPermanentlyFailed(id: string, attempts?: number): Message {
+    const attemptsClause = attempts !== undefined ? ', attempts = ?' : ''
+    const binds = attempts !== undefined
+      ? ['permanently_failed', attempts, id]
+      : ['permanently_failed', id]
+    const row = this.db.prepare(`
+      UPDATE messages
+      SET status = ?${attemptsClause},
+          updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+      WHERE id = ? AND status IN ('queued', 'sending', 'failed', 'waiting_device')
+      RETURNING *
+    `).get(...binds) as Record<string, unknown> | undefined
+
+    if (!row) throw new Error(`Message not found or invalid state for permanently_failed: ${id}`)
+    return this.rowToMessage(row)
   }
 
   cleanStaleLocks(): number {

--- a/packages/core/src/queue/types.ts
+++ b/packages/core/src/queue/types.ts
@@ -33,6 +33,7 @@ export interface Message {
   context: string | null
   wahaMessageId: string | null
   maxRetries: number
+  sentAt: string | null
   fallbackUsed: number
   fallbackProvider: string | null
   screenshotPath: string | null

--- a/packages/core/src/queue/types.ts
+++ b/packages/core/src/queue/types.ts
@@ -12,6 +12,7 @@ export interface EnqueueParams {
   mediaUrl?: string
   mediaType?: string
   mediaCaption?: string
+  contactName?: string
 }
 
 export interface Message {
@@ -50,6 +51,27 @@ export type MessageStatus =
   | 'failed'
   | 'permanently_failed'
   | 'waiting_device'
+
+export const VALID_TRANSITIONS: Record<MessageStatus, MessageStatus[]> = {
+  queued: ['locked', 'waiting_device', 'permanently_failed'],
+  locked: ['sending', 'queued'],
+  sending: ['sent', 'failed', 'queued', 'permanently_failed'],
+  sent: [],
+  failed: ['queued', 'permanently_failed'],
+  permanently_failed: ['queued'],
+  waiting_device: ['queued', 'permanently_failed'],
+}
+
+export interface SkippedItem {
+  idempotencyKey: string
+  reason: 'blacklisted' | 'duplicate'
+  to?: string
+}
+
+export interface BatchResult {
+  enqueued: Message[]
+  skipped: SkippedItem[]
+}
 
 export interface PaginatedFilters {
   limit?: number

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -266,7 +266,7 @@ export async function createServer(port = Number(process.env.PORT) || 7890): Pro
 
     // Re-queue failed messages, then lock via dequeue to prevent auto-worker collision
     if (message.status === 'failed') {
-      queue.updateStatus(id, 'queued')
+      queue.updateStatus(id, 'failed', 'queued')
     }
     const locked = queue.dequeue(online.serial)
     if (!locked || locked.id !== id) {
@@ -277,6 +277,8 @@ export async function createServer(port = Number(process.env.PORT) || 7890): Pro
       const result = await engine.send(locked, online.serial)
       return { status: 'sent', durationMs: result.durationMs }
     } catch (err) {
+      // Set failed status since there's no orchestrator WAHA fallback for manual sends
+      try { queue.updateStatus(id, 'sending', 'failed') } catch { /* ignore CAS mismatch */ }
       return reply.status(500).send({
         error: 'Send failed',
         detail: err instanceof Error ? err.message : String(err),

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -1,4 +1,5 @@
 import { readdir, unlink, stat } from 'node:fs/promises'
+import { timingSafeEqual } from 'node:crypto'
 import Fastify from 'fastify'
 import cors from '@fastify/cors'
 import Database from 'better-sqlite3'
@@ -42,6 +43,7 @@ export async function createServer(port = Number(process.env.PORT) || 7890): Pro
   const loggerConfig = buildLoggerConfig(process.env.NODE_ENV, process.env.LOG_FILE)
   const server = Fastify({
     logger: loggerConfig,
+    bodyLimit: 1_048_576, // S8: 1MB body limit
   })
   const corsOrigins = buildCorsOrigins(process.env.DISPATCH_ALLOWED_ORIGINS)
   await server.register(cors, { origin: corsOrigins })
@@ -342,10 +344,18 @@ export async function createServer(port = Number(process.env.PORT) || 7890): Pro
     const fullPath = `/api/v1/plugins/${route.pluginName}${route.path}`
     const method = route.method.toLowerCase() as 'get' | 'post' | 'put' | 'patch' | 'delete'
 
+    // S7: validate plugin route paths
+    if (!/^\/[a-zA-Z0-9/_-]*$/.test(route.path)) {
+      server.log.error({ plugin: route.pluginName, path: route.path }, 'Invalid plugin route path, skipping')
+      continue
+    }
+
     server[method](fullPath, async (req, reply) => {
-      if (apiKey && method === 'post') {
-        const providedKey = (req.headers as Record<string, string>)['x-api-key']
-        if (providedKey !== apiKey) {
+      // S1/S2: timingSafeEqual auth for ALL HTTP methods
+      if (apiKey) {
+        const providedKey = (req.headers as Record<string, string>)['x-api-key'] ?? ''
+        if (providedKey.length !== apiKey.length ||
+            !timingSafeEqual(Buffer.from(providedKey), Buffer.from(apiKey))) {
           return reply.status(401).send({ error: 'Invalid API key' })
         }
       }
@@ -401,7 +411,7 @@ export async function createServer(port = Number(process.env.PORT) || 7890): Pro
           },
           error: null,
           fallback_reason: msg.fallbackUsed ? { original_error: 'adb_failed', original_session: senderSession, quarantined: false } : undefined,
-          context: msg.context ? JSON.parse(msg.context) : undefined,
+          context: msg.context ? (() => { try { return JSON.parse(msg.context!) } catch { return undefined } })() : undefined,
         })
       }
     })
@@ -421,7 +431,7 @@ export async function createServer(port = Number(process.env.PORT) || 7890): Pro
             message: data.error,
             retryable: msg.attempts < msg.maxRetries,
           },
-          context: msg.context ? JSON.parse(msg.context) : undefined,
+          context: msg.context ? (() => { try { return JSON.parse(msg.context!) } catch { return undefined } })() : undefined,
         })
       }
     })
@@ -537,16 +547,22 @@ export async function createServer(port = Number(process.env.PORT) || 7890): Pro
     }
   })
 
+  // S4: Strip secrets from admin GET responses
+  const sanitizePlugin = (p: { api_key: string; hmac_secret: string; [key: string]: unknown }) => {
+    const { api_key: _ak, hmac_secret: _hs, ...safe } = p
+    return safe
+  }
+
   // Admin routes for plugin management
   server.get('/api/v1/admin/plugins', async (_req, reply) => {
-    return reply.send(pluginRegistry.listPlugins())
+    return reply.send(pluginRegistry.listPlugins().map(sanitizePlugin))
   })
 
   server.get('/api/v1/admin/plugins/:name', async (req, reply) => {
     const { name } = req.params as { name: string }
     const plugin = pluginRegistry.getPlugin(name)
     if (!plugin) return reply.status(404).send({ error: 'Plugin not found' })
-    return reply.send(plugin)
+    return reply.send(sanitizePlugin(plugin))
   })
 
   server.patch('/api/v1/admin/plugins/:name', async (req, reply) => {

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -20,7 +20,7 @@ import { RateLimitGuard } from './config/rate-limits.js'
 import { parseConfig } from './config/config-schema.js'
 import { AuditLogger } from './config/audit-logger.js'
 import { ScreenshotPolicy } from './config/screenshot-policy.js'
-import { metricsRegistry, messagesSentTotal, messagesFailedTotal, messagesQueuedTotal, sendDurationSeconds, interMessageDelaySeconds, queueDepth, devicesOnline, senderDailyCount, quarantineEventsTotal, senderQuarantined } from './config/metrics.js'
+import { metricsRegistry, messagesSentTotal, messagesFailedTotal, messagesQueuedTotal, sendDurationSeconds, interMessageDelaySeconds, queueDepth, devicesOnline, senderDailyCount, quarantineEventsTotal, senderQuarantined, callbacksTotal, pluginErrorsTotal, queueDepthByPlugin } from './config/metrics.js'
 import { OralsinPlugin } from './plugins/oralsin-plugin.js'
 import type { DispatchEventName } from './events/index.js'
 import type { DispatchPlugin } from './plugins/types.js'
@@ -309,6 +309,13 @@ export async function createServer(port = Number(process.env.PORT) || 7890): Pro
   const pluginRegistry = new PluginRegistry(db)
   pluginRegistry.initialize()
   const pluginEventBus = new PluginEventBus(pluginRegistry, emitter)
+
+  // A3/Decision #20: Wire onError with log + metric
+  pluginEventBus.onError((pluginName, event, error) => {
+    server.log.error({ plugin: pluginName, event, err: error }, 'Plugin handler error')
+    pluginErrorsTotal.inc({ plugin: pluginName, event })
+  })
+
   const callbackDelivery = new CallbackDelivery(db, pluginRegistry, fetch)
   const pinoLogger = { child: (bindings: Record<string, unknown>) => ({ info: server.log.info.bind(server.log), warn: server.log.warn.bind(server.log), error: server.log.error.bind(server.log), debug: server.log.debug.bind(server.log) }) }
   const pluginLoader = new PluginLoader(pluginRegistry, pluginEventBus, queue, db, pinoLogger, senderMapping, engine)

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -326,8 +326,12 @@ export async function createServer(port = Number(process.env.PORT) || 7890): Pro
     const plugin = factory()
     const apiKey = process.env[`PLUGIN_${name.toUpperCase()}_API_KEY`] || ''
     const hmacSecret = process.env[`PLUGIN_${name.toUpperCase()}_HMAC_SECRET`] || ''
-    await pluginLoader.loadPlugin(plugin, apiKey, hmacSecret)
-    server.log.info({ plugin: name }, 'Plugin loaded')
+    try {
+      await pluginLoader.loadPlugin(plugin, apiKey, hmacSecret)
+      server.log.info({ plugin: name }, 'Plugin loaded')
+    } catch (err) {
+      server.log.error({ plugin: name, err }, 'Plugin failed to load, skipping')
+    }
   }
 
   // Register plugin routes on Fastify (generic — works for any plugin)

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -51,6 +51,8 @@ export async function createServer(port = Number(process.env.PORT) || 7890): Pro
 
   const db = new Database(process.env.DB_PATH || 'dispatch.db')
   db.pragma('journal_mode = WAL')
+  db.pragma('busy_timeout = 5000')
+  db.pragma('wal_autocheckpoint = 400')
 
   const queue = new MessageQueue(db)
   queue.initialize()

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -23,7 +23,7 @@ import { ScreenshotPolicy } from './config/screenshot-policy.js'
 import { metricsRegistry, messagesSentTotal, messagesFailedTotal, messagesQueuedTotal, sendDurationSeconds, interMessageDelaySeconds, queueDepth, devicesOnline, senderDailyCount, quarantineEventsTotal, senderQuarantined, callbacksTotal, pluginErrorsTotal, queueDepthByPlugin } from './config/metrics.js'
 import { OralsinPlugin } from './plugins/oralsin-plugin.js'
 import type { DispatchEventName } from './events/index.js'
-import type { DispatchPlugin } from './plugins/types.js'
+import type { DispatchPlugin, PluginRecord } from './plugins/types.js'
 
 export interface DispatchCore {
   server: ReturnType<typeof Fastify>
@@ -555,7 +555,7 @@ export async function createServer(port = Number(process.env.PORT) || 7890): Pro
   })
 
   // S4: Strip secrets from admin GET responses
-  const sanitizePlugin = (p: { api_key: string; hmac_secret: string; [key: string]: unknown }) => {
+  const sanitizePlugin = (p: PluginRecord) => {
     const { api_key: _ak, hmac_secret: _hs, ...safe } = p
     return safe
   }
@@ -584,8 +584,8 @@ export async function createServer(port = Number(process.env.PORT) || 7890): Pro
       action: 'update',
       resourceType: 'plugin',
       resourceId: name,
-      beforeState: beforeState ? { status: beforeState.status, webhookUrl: beforeState.webhookUrl, events: beforeState.events } : null,
-      afterState: afterState ? { status: afterState.status, webhookUrl: afterState.webhookUrl, events: afterState.events } : null,
+      beforeState: beforeState ? { status: beforeState.status, webhookUrl: beforeState.webhook_url, events: beforeState.events } : null,
+      afterState: afterState ? { status: afterState.status, webhookUrl: afterState.webhook_url, events: afterState.events } : null,
     })
     return reply.send(afterState)
   })
@@ -598,7 +598,7 @@ export async function createServer(port = Number(process.env.PORT) || 7890): Pro
       action: 'delete',
       resourceType: 'plugin',
       resourceId: name,
-      beforeState: beforeState ? { status: beforeState.status, webhookUrl: beforeState.webhookUrl, events: beforeState.events } : null,
+      beforeState: beforeState ? { status: beforeState.status, webhookUrl: beforeState.webhook_url, events: beforeState.events } : null,
     })
     return reply.status(204).send()
   })

--- a/packages/core/src/waha/independence.test.ts
+++ b/packages/core/src/waha/independence.test.ts
@@ -132,8 +132,9 @@ describe('WAHA-ADB Independence', () => {
     expect(first).not.toBeNull()
     expect(first!.body).toBe('Message 1')
 
-    // Simulate send completion
-    queue.updateStatus(first!.id, 'sent')
+    // Simulate send completion (locked → sending → sent)
+    queue.updateStatus(first!.id, 'locked', 'sending')
+    queue.updateStatus(first!.id, 'sending', 'sent')
 
     const second = queue.dequeue('POCO-001')
     expect(second).not.toBeNull()

--- a/plans/plugin-hardening-sprint.md
+++ b/plans/plugin-hardening-sprint.md
@@ -1,0 +1,1186 @@
+# Plugin Hardening Sprint — Execution Plan
+
+> **Date**: 2026-04-13
+> **Scope**: 87 findings + 43 grill decisions — full hardening of plugin system
+> **Strategy**: Sequential batches by layer, DB first, commits atomics
+> **Context Recovery**: This plan is self-contained for zero-context execution after `/clear`
+> **Grill**: 43 decisions documented in `.dev-state/plugin-hardening-grill.md`
+> **Branch**: `hardening/plugin-system`
+
+## Pre-Execution Checklist
+
+```bash
+# 1. Read this plan
+cat plans/plugin-hardening-sprint.md
+
+# 2. Read grill decisions
+cat .dev-state/plugin-hardening-grill.md
+
+# 3. Verify tests pass
+cd /var/www/adb_tools && pnpm test
+
+# 4. Create branch
+git checkout -b hardening/plugin-system
+
+# 5. Clean DB (recreate tables — grill decision #4)
+rm -f packages/core/dispatch.db packages/core/dispatch.db-wal packages/core/dispatch.db-shm
+```
+
+## Dependency Graph
+
+```
+Batch 1 (DB/Schema)
+  │
+  ├──► Batch 2 (State Machine + Queue)
+  │       │
+  │       ├──► Batch 3 (Plugin Core)
+  │       │       │
+  │       │       ├──► Batch 4 (Callback System)
+  │       │       │       │
+  │       │       │       ├──► Batch 5 (Oralsin Plugin Contract)
+  │       │       │       │       │
+  │       │       │       │       ├──► Batch 6 (Server Integration)
+  │       │       │       │       │       │
+  │       │       │       │       │       ├──► Batch 7 (Observability + Metrics)
+  │       │       │       │       │       │       │
+  │       │       │       │       │       │       ├──► Batch 8 (Resilience + Recovery)
+  │       │       │       │       │       │       │       │
+  │       │       │       │       │       │       │       └──► Batch 9 (Tests)
+  │       │       │       │       │       │       │               │
+  │       │       │       │       │       │       │               └──► Batch 10 (Grafana + Docs)
+```
+
+---
+
+## Batch 1: DB Schema & Configuration Hardening
+
+**Commit**: `fix(db): schema hardening — busy_timeout, indexes, timestamps, constraints`
+**Findings**: DB1, DB2, DB3, DB4, DB5, DB8, DB9, D4, D6, D7
+**Decisions**: #3, #4, #19, #35, #36
+
+### Files to Modify
+
+#### `packages/core/src/queue/message-queue.ts` (522 lines)
+
+**DB1** — Add `PRAGMA busy_timeout = 5000` after WAL mode (line ~26):
+```typescript
+db.pragma('journal_mode = WAL')
+db.pragma('busy_timeout = 5000')
+```
+
+**DB2** — Add index on `messages(plugin_name, status, created_at)` in `initialize()`:
+```sql
+CREATE INDEX IF NOT EXISTS idx_messages_plugin_name ON messages(plugin_name, status, created_at)
+```
+
+**DB5** — Add WAL checkpoint config:
+```typescript
+db.pragma('wal_autocheckpoint = 400')
+```
+
+**DB8** — Add CHECK constraint on priority in CREATE TABLE:
+```sql
+priority INTEGER NOT NULL DEFAULT 5 CHECK (priority BETWEEN 1 AND 10)
+```
+
+**D4** — Add `sent_at` column to messages CREATE TABLE:
+```sql
+sent_at TEXT DEFAULT NULL
+```
+Update `updateStatus` to set `sent_at` when transitioning to `sent`:
+```typescript
+if (to === 'sent') {
+  // also set sent_at
+}
+```
+
+**DB4** — Rewrite `getQueueStats` to branch instead of `IS NULL OR`:
+```typescript
+getQueueStats(pluginName?: string) {
+  const baseWhere = pluginName ? 'WHERE plugin_name = ?' : ''
+  const binds = pluginName ? [pluginName] : []
+  // single query with FILTER and dynamic WHERE
+}
+```
+
+#### `packages/core/src/plugins/plugin-registry.ts` (160 lines)
+
+**D7** — Replace all `datetime('now')` with `strftime('%Y-%m-%dT%H:%M:%fZ', 'now')` in:
+- `plugins` table DDL (created_at, updated_at defaults)
+- `failed_callbacks` table DDL (created_at, last_attempt_at defaults)
+- All UPDATE statements
+
+**DB3** — Add composite index on `failed_callbacks`:
+```sql
+CREATE INDEX IF NOT EXISTS idx_failed_callbacks_retry ON failed_callbacks(attempts, created_at)
+```
+
+**D6** — Enable foreign keys and add FK constraints:
+```typescript
+db.pragma('foreign_keys = ON')
+```
+Add to `messages` CREATE TABLE:
+```sql
+plugin_name TEXT REFERENCES plugins(name) ON DELETE SET NULL
+```
+Add to `failed_callbacks` CREATE TABLE:
+```sql
+plugin_name TEXT NOT NULL REFERENCES plugins(name) ON DELETE CASCADE
+```
+
+**DB9** — Fix `pending_correlations` timestamps in `receipt-tracker.ts`:
+Replace `datetime('now')` with `strftime('%Y-%m-%dT%H:%M:%fZ', 'now')`.
+
+#### `packages/core/src/engine/receipt-tracker.ts` (175 lines)
+
+**DB9** — Normalize timestamps to ISO 8601 with milliseconds.
+
+#### `packages/core/src/config/config-schema.ts` (184 lines)
+
+**DB5** — Add WAL checkpoint to hourly cleanup in server.ts (this is a server.ts change but schema-related).
+
+### Acceptance Criteria
+- [ ] `PRAGMA busy_timeout` returns 5000
+- [ ] `PRAGMA foreign_keys` returns 1
+- [ ] Index `idx_messages_plugin_name` exists
+- [ ] Index `idx_failed_callbacks_retry` exists
+- [ ] `messages.sent_at` column exists
+- [ ] `messages.priority` has CHECK constraint
+- [ ] All timestamps use ISO 8601 with milliseconds
+- [ ] Tests pass after schema changes
+
+---
+
+## Batch 2: State Machine & Queue Integrity
+
+**Commit**: `fix(queue): enforced state machine, waiting_device, TTL, batch partial-failure`
+**Findings**: D1, D2, D3, D5, D8, R4, R6, P8, P11
+**Decisions**: #7, #8, #9, #10, #29, #31, #35
+
+### Files to Modify
+
+#### `packages/core/src/queue/types.ts` (67 lines)
+
+**D1/D2** — Define valid state transitions as a const map:
+```typescript
+export const VALID_TRANSITIONS: Record<MessageStatus, MessageStatus[]> = {
+  queued: ['locked', 'waiting_device', 'permanently_failed'],
+  locked: ['sending', 'queued'],
+  sending: ['sent', 'failed', 'queued'],
+  sent: [],
+  failed: ['queued', 'permanently_failed'],
+  permanently_failed: ['queued'],  // manual retry only
+  waiting_device: ['queued', 'permanently_failed'],
+}
+```
+
+**D8** — Export `PluginStatus` type for use in plugin-registry.
+
+#### `packages/core/src/queue/message-queue.ts` (522 lines)
+
+**D2** — Enforce state machine in `updateStatus(id, from, to)`:
+```typescript
+updateStatus(id: string, from: MessageStatus, to: MessageStatus): void {
+  if (!VALID_TRANSITIONS[from]?.includes(to)) {
+    throw new Error(`Invalid transition: ${from} → ${to}`)
+  }
+  // UPDATE ... WHERE id = ? AND status = ? (CAS)
+}
+```
+All callers must pass `from` status.
+
+**R4/P8** — Rewrite `enqueueBatch` with partial-failure semantics:
+- `ON CONFLICT(idempotency_key) DO NOTHING`
+- Blacklisted numbers: skip per-item, add to `skipped[]`
+- Return `{ enqueued: Message[], skipped: SkippedItem[], duplicated: string[] }`
+- Transaction wraps all inserts (including `saveContact` — fix D5)
+
+**D5** — Move `saveContact` inside the `enqueueBatch` transaction.
+
+**P11** — Fix maxRetries semantics: `attempts >= maxRetries` (not `attempts + 1 < maxRetries`).
+
+**D3** — When transitioning to `permanently_failed`, set `attempts` to the real value:
+```typescript
+// In requeueForRetry or updateStatus to permanently_failed:
+db.prepare('UPDATE messages SET status = ?, attempts = ? ...').run('permanently_failed', actualAttempts)
+```
+
+**R6** — Add `waiting_device` transition logic:
+- New method: `transitionToWaitingDevice()` — moves `queued` messages to `waiting_device` when no devices online
+- New method: `transitionFromWaitingDevice()` — moves `waiting_device` back to `queued` when device comes online
+- TTL check: messages in `waiting_device` older than threshold → `permanently_failed`
+
+**D4** — Populate `sent_at` in the state machine when `to === 'sent'`.
+
+#### `packages/core/src/engine/worker-orchestrator.ts` (340 lines)
+
+**P11** — Update retry check to `message.attempts >= message.maxRetries`.
+
+**D2** — Update all `updateStatus` calls to pass `from` parameter.
+
+**D3** — Ensure `permanently_failed` path sets real `attempts` count.
+
+### Acceptance Criteria
+- [ ] `updateStatus(id, 'queued', 'sent')` throws (invalid transition)
+- [ ] `updateStatus(id, 'sending', 'sent')` succeeds
+- [ ] Batch with 1 blacklisted + 2 valid: 2 enqueued, 1 skipped
+- [ ] Batch with 1 duplicate idempotency_key: DO NOTHING, no rollback
+- [ ] `maxRetries=3` produces exactly 3 send attempts
+- [ ] `permanently_failed` messages have correct `attempts` count
+- [ ] `waiting_device` → `queued` transition works when device comes online
+- [ ] `saveContact` + `enqueueBatch` are atomic (single transaction)
+- [ ] Tests pass
+
+---
+
+## Batch 3: Plugin Core Modules
+
+**Commit**: `fix(plugins): lifecycle errors, registry sync, typed status, timer leak`
+**Findings**: R2, R3, R9, R10, D8, Q1, Q3, A3
+**Decisions**: #20, #33, #37
+
+### Files to Modify
+
+#### `packages/core/src/plugins/plugin-loader.ts` (196 lines)
+
+**R2** — Plugin init error: log + re-throw:
+```typescript
+} catch (err) {
+  this.registry.setPluginStatus(plugin.name, 'error')
+  this.logger.error({ err, plugin: plugin.name }, 'Plugin init failed')
+  throw err
+}
+```
+
+**R3** — `destroyAll` with try/catch per-plugin:
+```typescript
+async destroyAll(): Promise<void> {
+  for (const [name, plugin] of this.loadedPlugins) {
+    try {
+      await plugin.destroy()
+      this.loadedPlugins.delete(name)
+    } catch (err) {
+      this.logger.warn({ err, plugin: name }, 'Plugin destroy failed')
+    }
+  }
+}
+```
+
+**Q3** — Validate `pluginName` against registry at load time:
+```typescript
+const registered = this.registry.getPlugin(plugin.name)
+if (!registered) throw new Error(`Plugin ${plugin.name} not registered`)
+```
+
+#### `packages/core/src/plugins/plugin-event-bus.ts` (87 lines)
+
+**R9** — Remove `pluginEnabled` map. Use registry as source of truth:
+```typescript
+// In dispatchToPlugins:
+const pluginRecord = this.registry.getPlugin(pluginName)
+if (!pluginRecord || pluginRecord.enabled !== 1) return
+```
+
+**Q1** — Fix timer leak in `executeWithTimeout`:
+```typescript
+let timeoutHandle: ReturnType<typeof setTimeout>
+const timeout = new Promise<never>((_, reject) => {
+  timeoutHandle = setTimeout(() => reject(...), HANDLER_TIMEOUT_MS)
+})
+try {
+  await Promise.race([result, timeout])
+} finally {
+  clearTimeout(timeoutHandle!)
+}
+```
+
+**A3** — Wire `onError` (this is wired in server.ts but the handler must exist):
+Ensure `onError` callback interface is properly typed.
+
+#### `packages/core/src/plugins/plugin-registry.ts` (160 lines)
+
+**D8** — Type `setPluginStatus` parameter:
+```typescript
+import type { PluginStatus } from './types.js'
+setPluginStatus(name: string, status: PluginStatus): void {
+```
+
+**R10** — Upsert includes `api_key` and `hmac_secret`:
+```sql
+ON CONFLICT(name) DO UPDATE SET
+  version = excluded.version,
+  webhook_url = excluded.webhook_url,
+  api_key = excluded.api_key,
+  hmac_secret = excluded.hmac_secret,
+  events = excluded.events,
+  updated_at = strftime(...)
+```
+
+### Acceptance Criteria
+- [ ] Plugin init failure: logged at error level, status set to 'error', caller gets exception
+- [ ] `destroyAll` with 2 plugins (first throws): second still destroyed
+- [ ] Disabling plugin via admin API stops event dispatch (registry checked live)
+- [ ] `setPluginStatus('oralsin', 'invalid' as any)` — TypeScript compile error
+- [ ] Timer leak test: no pending timers after handler resolves
+- [ ] API key/HMAC secret updated on restart when env var changes
+- [ ] Tests pass
+
+---
+
+## Batch 4: Callback System
+
+**Commit**: `fix(callbacks): 503 retry, HMAC hardening, fetch timeout, error capture, interim_failure + expired types`
+**Findings**: S5, S15, R11, A5, A6, Q5, P5
+**Decisions**: #11, #27, #40, #41, #42, #43
+
+### Files to Modify
+
+#### `packages/core/src/plugins/types.ts` (205 lines)
+
+**Decision #11/#42** — Extend `CallbackType`:
+```typescript
+export type CallbackType = 'result' | 'ack' | 'response' | 'interim_failure' | 'expired'
+```
+
+Add `InterimFailureCallback` and `ExpiredCallback` interfaces:
+```typescript
+export interface InterimFailureCallback {
+  event: 'interim_failure'
+  idempotency_key: string
+  correlation_id?: string
+  status: 'interim_failed'
+  error: { code: string; message: string; retryable: boolean }
+  failed_sender: { phone: string; session: string; pair: string } | null
+  next_sender: { phone: string; session: string; pair: string; role: string } | null
+  attempt: number
+  context?: Record<string, unknown>
+}
+
+export interface ExpiredCallback {
+  event: 'expired'
+  idempotency_key: string
+  correlation_id?: string
+  status: 'expired'
+  error: { code: 'ttl_expired'; message: string; retryable: false }
+  context?: Record<string, unknown>
+}
+```
+
+Update `FallbackReason` to include real error:
+```typescript
+export interface FallbackReason {
+  original_error: string      // real engine error code, not hardcoded
+  original_message?: string   // human-readable detail
+  original_session: string
+  quarantined: boolean        // real quarantine state
+}
+```
+
+#### `packages/core/src/plugins/callback-delivery.ts` (181 lines)
+
+**Decision #40** — 503 is retryable with short backoff:
+```typescript
+// Remove the 503 break
+// Change backoff for 503:
+const BACKOFF_503_MS = [0, 1_000, 2_000, 4_000] as const
+// In the retry loop:
+if (response.status === 503) {
+  // use 503-specific backoff, continue retrying
+}
+```
+
+**S5** — HMAC empty secret = throw at plugin load (not at sign time):
+```typescript
+private sign(body: string, secret: string): string {
+  // secret emptiness is caught at boot via config-schema superRefine
+  return createHmac('sha256', secret).update(body).digest('hex')
+}
+```
+
+**S15/R11** — AbortSignal on all fetch calls:
+```typescript
+const controller = new AbortController()
+const timeoutMs = parseInt(process.env.DISPATCH_HTTP_TIMEOUT_MS ?? '10000')
+const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
+try {
+  const response = await fetch(url, { ...options, signal: controller.signal })
+} finally {
+  clearTimeout(timeoutId)
+}
+```
+
+**A5** — Capture response body in `last_error`:
+```typescript
+const bodyText = await response.text().catch(() => '')
+lastError = `HTTP ${response.status}: ${bodyText.slice(0, 500)}`
+```
+
+**A6/Q5** — Update `last_error` on every retry:
+```sql
+UPDATE failed_callbacks SET attempts = attempts + 1, last_attempt_at = ..., last_error = ? WHERE id = ?
+```
+
+Add methods: `sendInterimFailureCallback()`, `sendExpiredCallback()`.
+
+### Acceptance Criteria
+- [ ] 503 response: retried 4 times with [0, 1s, 2s, 4s] backoff
+- [ ] 400 response: breaks after 1 attempt (non-retryable)
+- [ ] 500 response: retried 4 times with standard backoff
+- [ ] Empty HMAC secret: server fails to boot
+- [ ] Fetch timeout: aborts after 10s (or configured value)
+- [ ] `failed_callbacks.last_error` contains response body on failure
+- [ ] `retryFailedCallback` updates `last_error` each attempt
+- [ ] `interim_failure` callback type works end-to-end
+- [ ] `expired` callback type works end-to-end
+- [ ] Tests pass (T3, T9, T12 covered here)
+
+---
+
+## Batch 5: Oralsin Plugin Contract
+
+**Commit**: `fix(oralsin): input validation, phone normalization, context merge, sender resolution`
+**Findings**: S9, S10, S11, S12, P1, P10, Q2
+**Decisions**: #17, #26, #29, #37, #39
+
+### Files to Modify
+
+#### `packages/core/src/plugins/oralsin-plugin.ts` (223 lines)
+
+**S11** — Phone fields E.164 regex:
+```typescript
+const phoneSchema = z.string().regex(/^\+?\d{10,15}$/, 'Must be 10-15 digits, optional + prefix')
+```
+Apply to `senderSchema.phone`, `patientSchema.phone`.
+
+**S10** — `message.text` max length:
+```typescript
+text: z.string().min(1).max(4096)
+```
+
+**S12** — Batch max:
+```typescript
+z.array(enqueueItemSchema).min(1).max(500)
+```
+
+**S9** — Context max size:
+```typescript
+context: z.record(z.unknown()).optional().superRefine((val, ctx) => {
+  if (val && JSON.stringify(val).length > 65536) {
+    ctx.addIssue({ code: 'custom', message: 'context exceeds 64KB' })
+  }
+})
+```
+
+#### `packages/core/src/plugins/plugin-loader.ts` (196 lines)
+
+**P1/Decision #17** — Merge `patientId` and `templateId` into context:
+```typescript
+const mergedContext = {
+  ...m.context,
+  ...(m.patient.patientId ? { patient_id: m.patient.patientId } : {}),
+  ...(m.message.templateId ? { template_id: m.message.templateId } : {}),
+}
+// store JSON.stringify(mergedContext) in context column
+```
+
+**P10** — Remove `senders[0]?.phone` fallback. Always use `resolveSenderChain`:
+```typescript
+// REMOVE: m.resolvedSenderPhone ?? m.senders[0]?.phone ?? null
+// REPLACE: m.resolvedSenderPhone ?? null
+// If null, the item was already rejected by oralsin-plugin.ts
+```
+
+#### `packages/core/src/engine/sender-mapping.ts` (207 lines)
+
+**Decision #39** — Normalize phone to digits-only in both create and lookup:
+```typescript
+private normalizePhone(phone: string): string {
+  return phone.replace(/\D/g, '')
+}
+
+create(params: CreateSenderMappingParams): SenderMappingRecord {
+  const normalized = this.normalizePhone(params.phoneNumber)
+  // INSERT with normalized
+}
+
+getByPhone(phoneNumber: string): SenderMappingRecord | null {
+  const normalized = this.normalizePhone(phoneNumber)
+  // SELECT with normalized
+}
+```
+
+**Q2** — `resolveSenderChain` filters paused senders:
+```typescript
+resolveSenderChain(senders: SenderConfig[]): ResolvedSender | null {
+  for (const sender of senders) {
+    const record = this.getByPhone(sender.phone)
+    if (record && record.paused === 0) {
+      return { mapping: record, sender }
+    }
+  }
+  return null
+}
+```
+
+### Acceptance Criteria
+- [ ] Phone "+554396837945" and "554396837945" both resolve to same sender_mapping row
+- [ ] `message.text` > 4096 chars: 400 error
+- [ ] Batch > 500 items: 400 error
+- [ ] Context > 64KB: 400 error
+- [ ] `patientId` and `templateId` appear in stored `context` JSON
+- [ ] Paused sender skipped, next sender in chain used
+- [ ] `senders[0]?.phone` fallback removed — no unresolved phone reaches DB
+- [ ] Tests pass (T5, T6 covered here)
+
+---
+
+## Batch 6: Server Integration
+
+**Commit**: `fix(server): auth hardening, plugin route security, config validation, callback wiring`
+**Findings**: S1, S2, S3, S4, S7, S8, S13, P2, P3, P6, P9, R12, A11, D43
+**Decisions**: #22, #25, #26, #32, #43
+
+### Files to Modify
+
+#### `packages/core/src/server.ts` (824 lines)
+
+**S1/S2** — Plugin route auth: `timingSafeEqual`, all HTTP methods:
+```typescript
+import { timingSafeEqual } from 'node:crypto'
+
+server[method](fullPath, async (req, reply) => {
+  if (apiKey) {
+    const providedKey = (req.headers as Record<string, string>)['x-api-key'] ?? ''
+    if (providedKey.length !== apiKey.length ||
+        !timingSafeEqual(Buffer.from(providedKey), Buffer.from(apiKey))) {
+      return reply.status(401).send({ error: 'Invalid API key' })
+    }
+  }
+  return route.handler(req, reply)
+})
+```
+
+**S4** — Strip secrets from admin GET responses:
+```typescript
+const sanitize = (p: PluginRecord) => {
+  const { api_key, hmac_secret, ...safe } = p
+  return safe
+}
+```
+
+**S7** — Validate plugin route paths:
+```typescript
+if (!/^\/[a-zA-Z0-9/_-]*$/.test(route.path)) {
+  throw new Error(`Plugin ${route.pluginName}: invalid route path: ${route.path}`)
+}
+```
+
+**S8** — Fastify body limit:
+```typescript
+const server = Fastify({ logger: loggerConfig, bodyLimit: 1_048_576 })
+```
+
+**S13** — `/healthz` degraded without API key:
+```typescript
+// If no valid API key provided, return minimal response
+return reply.send({ status: 'ok' })
+// With API key: return full topology
+```
+
+**A11** — Fix pino logger child:
+```typescript
+const pinoLogger = {
+  child: (bindings: Record<string, unknown>) => server.log.child(bindings)
+}
+```
+
+**P2** — Emit `message:queued` from plugin enqueue path:
+```typescript
+// After enqueueBatch returns, for each message:
+emitter.emit('message:queued', { id: msg.id, pluginName: msg.pluginName })
+```
+
+**P3** — Guard `JSON.parse(msg.context)`:
+```typescript
+let parsedContext: Record<string, unknown> | undefined
+try {
+  parsedContext = msg.context ? JSON.parse(msg.context) : undefined
+} catch (err) {
+  server.log.error({ err, messageId: msg.id }, 'Malformed context JSON')
+  parsedContext = undefined
+}
+```
+
+**P6** — WAHA fallback `message:sent` includes all fields (in worker-orchestrator.ts):
+```typescript
+emitter.emit('message:sent', {
+  id: message.id,
+  sentAt: new Date().toISOString(),
+  durationMs: elapsed,
+  deviceSerial,
+  contactRegistered: false,
+  dialogsDismissed: 0,
+  strategyMethod: 'waha_fallback',
+  appPackage: message.appPackage ?? 'com.whatsapp',
+  senderNumber: message.senderNumber,
+})
+```
+
+**P9** — Scope `waha:message_received` query:
+```typescript
+const incomingHistory = messageHistory.query({
+  fromNumber: data.fromNumber,
+  toNumber: data.toNumber,
+  direction: 'incoming',
+  limit: 1,
+})
+if (!incomingHistory.length || !incomingHistory[0].text) return
+```
+
+**Decision #43** — `fallback_reason` with real error (requires storing error in sendMetadata or DB):
+```typescript
+// In worker-orchestrator processMessage catch:
+const errorCode = classifyError(err) // 'ban_detected', 'device_offline', 'typing_timeout', etc.
+orchestrator.storeFallbackError(message.id, errorCode, err.message)
+
+// In server.ts callback builder:
+fallback_reason: msg.fallbackUsed ? {
+  original_error: orchestrator.getFallbackError(data.id)?.code ?? 'adb_failed',
+  original_message: orchestrator.getFallbackError(data.id)?.message,
+  original_session: senderSession,
+  quarantined: senderHealth.isQuarantined(msg.senderNumber),
+} : undefined
+```
+
+**R12** — Webhook URL mandatory check moved to config-schema (handled in Batch 6 config).
+
+#### `packages/core/src/config/config-schema.ts` (184 lines)
+
+**S3/R12/Decision #22** — Add conditional required fields in `superRefine`:
+```typescript
+const plugins = data.DISPATCH_PLUGINS?.split(',').map(s => s.trim()).filter(Boolean) ?? []
+if (plugins.includes('oralsin')) {
+  if (!data.PLUGIN_ORALSIN_API_KEY) ctx.addIssue({ ... })
+  if (!data.PLUGIN_ORALSIN_HMAC_SECRET) ctx.addIssue({ ... })
+  if (!data.PLUGIN_ORALSIN_WEBHOOK_URL) ctx.addIssue({ ... })
+}
+if (plugins.length > 0 && !data.DISPATCH_WEBHOOK_ALLOWED_DOMAINS) {
+  ctx.addIssue({ message: 'DISPATCH_WEBHOOK_ALLOWED_DOMAINS required when plugins enabled' })
+}
+```
+
+Add new env vars:
+```typescript
+DISPATCH_WEBHOOK_ALLOWED_DOMAINS: z.string().optional(),
+DISPATCH_HTTP_TIMEOUT_MS: z.coerce.number().int().min(1000).max(60000).default(10000),
+```
+
+**Decision #22** — Webhook URL allowlist validation utility:
+```typescript
+function validateWebhookUrl(url: string, allowedDomains: string[], isProd: boolean): boolean {
+  const parsed = new URL(url)
+  if (isProd && parsed.protocol !== 'https:') return false
+  return allowedDomains.some(domain => parsed.hostname.endsWith(domain))
+}
+```
+
+#### `packages/core/src/api/api-auth.ts` (37 lines)
+
+**S13/Decision #12** — Remove `/metrics` from `PUBLIC_ROUTES`:
+```typescript
+const PUBLIC_ROUTES = [
+  '/api/v1/health',
+  // '/metrics' removed — now requires API key
+]
+```
+
+#### `packages/core/src/engine/worker-orchestrator.ts` (340 lines)
+
+**P6** — Populate all fields in WAHA fallback emit (see above).
+
+**D2** — Update all `updateStatus` calls to pass `from` parameter.
+
+### Acceptance Criteria
+- [ ] GET plugin route requires API key
+- [ ] Admin GET does not expose `api_key` or `hmac_secret`
+- [ ] Body > 1MB: 413 error
+- [ ] Plugin route with path `/../admin`: rejected at registration
+- [ ] `/healthz` without API key: returns only `{ status: "ok" }`
+- [ ] `/metrics` without API key: 401
+- [ ] Missing `PLUGIN_ORALSIN_API_KEY` with `DISPATCH_PLUGINS=oralsin`: boot fails
+- [ ] `message:queued` event fires for plugin enqueue
+- [ ] Malformed context JSON: logged, callback sent with undefined context
+- [ ] WAHA fallback callback has `senderNumber`, `strategyMethod: 'waha_fallback'`
+- [ ] `fallback_reason.original_error` contains real engine error
+- [ ] Tests pass
+
+---
+
+## Batch 7: Observability & Metrics
+
+**Commit**: `feat(metrics): plugin metrics, callback counters, queue depth per-plugin, dashboards`
+**Findings**: A4, A7, A8, A9, A10, A12, A13
+**Decisions**: #20, #23, #34
+
+### Files to Modify
+
+#### `packages/core/src/config/metrics.ts` (88 lines)
+
+Add 4+ new metrics:
+```typescript
+// Callback delivery
+export const callbacksTotal = new Counter({
+  name: 'dispatch_callbacks_total',
+  help: 'Total callbacks sent',
+  labelNames: ['plugin', 'type', 'status'],  // type: result/ack/interim_failure/expired, status: success/failed
+})
+
+// Plugin errors
+export const pluginErrorsTotal = new Counter({
+  name: 'dispatch_plugin_errors_total',
+  help: 'Plugin handler errors',
+  labelNames: ['plugin', 'event'],
+})
+
+// Queue depth per plugin
+export const queueDepthByPlugin = new Gauge({
+  name: 'dispatch_queue_depth_by_plugin',
+  help: 'Queue depth per plugin',
+  labelNames: ['plugin', 'status'],
+})
+
+// WAHA dedup misses
+export const wahaDedupmissTotal = new Counter({
+  name: 'dispatch_waha_dedup_miss_total',
+  help: 'WAHA dedup window misses',
+})
+```
+
+**A7** — Fix `messagesQueuedTotal` label:
+```typescript
+// In server.ts message:queued listener:
+messagesQueuedTotal.inc({ plugin: data.pluginName ?? 'direct' })
+```
+
+**A9** — Fix exhausted threshold:
+```typescript
+// In server.ts message:failed listener:
+const isExhausted = data.attempts >= (msg?.maxRetries ?? 3)
+messagesFailedTotal.inc({ sender: data.senderNumber ?? 'unknown', error_type: isExhausted ? 'exhausted' : 'transient' })
+```
+
+#### `packages/core/src/server.ts` (824 lines)
+
+**A3/Decision #20** — Wire `pluginEventBus.onError()`:
+```typescript
+pluginEventBus.onError((pluginName, event, error) => {
+  server.log.error({ plugin: pluginName, event, err: error }, 'Plugin handler error')
+  pluginErrorsTotal.inc({ plugin: pluginName, event })
+})
+```
+
+**A4** — Log + metric on callback success:
+```typescript
+// In callback-delivery.ts after successful delivery:
+callbacksTotal.inc({ plugin: pluginName, type: callbackType, status: 'success' })
+```
+
+**A13** — WAHA dedup miss signal:
+```typescript
+// In webhook-handler.ts when findByDedup returns null for outgoing:
+server.log.warn({ toNumber, wahaTimestamp }, 'WAHA dedup window miss — no matching ADB send')
+wahaDedupmissTotal.inc()
+```
+
+#### `packages/core/src/api/audit.ts` (348 lines)
+
+**A12** — Document event-sourcing contract: every status transition must write a `message_events` row. Add missing events for `cleanStaleLocks` and requeue paths.
+
+#### `packages/core/src/waha/webhook-handler.ts` (154 lines)
+
+**A13** — Log warning on dedup miss.
+**P7/Decision #18** — Unify dedup window to 30s.
+
+#### Grafana Dashboards
+
+Update 4 dashboard JSON files in `monitoring/grafana/dashboards/`:
+- `dispatch-overview.json`: Add callback success/failure panels, queue depth per plugin
+- `sender-health.json`: Add plugin error rate panel
+- Add `dispatch_waha_dedup_miss_total` to anti-ban dashboard
+
+### Acceptance Criteria
+- [ ] `dispatch_callbacks_total{plugin="oralsin",type="result",status="success"}` increments on callback delivery
+- [ ] `dispatch_plugin_errors_total{plugin="oralsin",event="message:sent"}` increments on handler error
+- [ ] `dispatch_queue_depth_by_plugin{plugin="oralsin",status="queued"}` reflects actual queue state
+- [ ] `dispatch_waha_dedup_miss_total` increments on window miss
+- [ ] `messagesQueuedTotal` uses actual plugin name
+- [ ] Exhausted threshold matches `message.maxRetries`
+- [ ] Grafana dashboards updated with new panels
+- [ ] Tests pass
+
+---
+
+## Batch 8: Resilience & Recovery
+
+**Commit**: `fix(resilience): sending recovery, graceful shutdown, backoff, TTL, interim_failure wiring`
+**Findings**: R1, R5, R7, A1, A2, P5
+**Decisions**: #8, #9, #14, #15, #21, #41, #42
+
+### Files to Modify
+
+#### `packages/core/src/queue/message-queue.ts` (522 lines)
+
+**R1/Decision #9** — Extend `cleanStaleLocks` to recover `sending`:
+```typescript
+// Recover locked > 120s
+// Recover sending > 300s (2x worst case send timeout)
+cleanStaleLocks(): number {
+  const lockedCount = db.prepare(`
+    UPDATE messages SET status = 'queued', locked_by = NULL, locked_at = NULL, updated_at = ...
+    WHERE status = 'locked' AND locked_at < datetime('now', '-120 seconds')
+  `).run().changes
+
+  const sendingCount = db.prepare(`
+    UPDATE messages SET status = 'queued', locked_by = NULL, locked_at = NULL, updated_at = ...
+    WHERE status = 'sending' AND updated_at < datetime('now', '-300 seconds')
+  `).run().changes
+
+  return lockedCount + sendingCount
+}
+```
+
+**A1** — Log stale lock recovery + write `message_events`:
+```typescript
+if (count > 0) {
+  logger.info({ event: 'stale_recovery', lockedCount, sendingCount }, 'Recovered stale messages')
+  // Write message_events for each recovered message
+}
+```
+
+#### `packages/core/src/engine/worker-orchestrator.ts` (340 lines)
+
+**R7/Decision #15** — Backoff exponencial no tick:
+```typescript
+private tickBackoff = 5_000 // base 5s
+private readonly MAX_BACKOFF = 60_000
+
+tick(): void {
+  // ... existing logic
+  if (sentCount === 0) {
+    this.tickBackoff = Math.min(this.tickBackoff * 2, this.MAX_BACKOFF)
+  } else {
+    this.tickBackoff = 5_000 // reset on success
+  }
+}
+
+getTickInterval(): number { return this.tickBackoff }
+```
+Server.ts: use dynamic interval instead of fixed 5000ms.
+
+**A2** — User-switch requeue writes `message_events`:
+```typescript
+// When requeuing due to device switch failure:
+for (const msg of batch) {
+  this.recorder?.record(msg.id, 'requeue_device_switch', { reason: 'switchToUser failed' })
+  queue.updateStatus(msg.id, 'locked', 'queued')
+}
+```
+
+**Decision #41** — `interim_failure` callback wiring:
+```typescript
+// In processMessage catch (ADB failed, before WAHA fallback):
+const errorCode = classifyError(err)
+callbackDelivery.sendInterimFailureCallback(msg.pluginName, msg.id, {
+  idempotency_key: msg.idempotencyKey,
+  correlation_id: msg.correlationId,
+  error: { code: errorCode, message: err.message, retryable: true },
+  failed_sender: { phone: msg.senderNumber, session: senderSession, pair: pairUsed },
+  next_sender: nextSenderInChain ?? null,
+  attempt: msg.attempts + 1,
+  context: msg.context ? JSON.parse(msg.context) : undefined,
+})
+```
+
+**Decision #42** — `expired` callback wiring (in TTL check):
+```typescript
+// When waiting_device → permanently_failed due to TTL:
+callbackDelivery.sendExpiredCallback(msg.pluginName, msg.id, {
+  idempotency_key: msg.idempotencyKey,
+  correlation_id: msg.correlationId,
+  error: { code: 'ttl_expired', message: `No device available for ${ttlHours}h`, retryable: false },
+  context: msg.context ? JSON.parse(msg.context) : undefined,
+})
+```
+
+#### `packages/core/src/config/graceful-shutdown.ts` (99 lines)
+
+**R5/Decision #14** — Wire `markSendActive`:
+```typescript
+// In worker-orchestrator processMessage:
+const sendPromise = engine.send(deviceSerial, message, appPackage)
+gracefulShutdown.markSendActive(sendPromise)
+await sendPromise
+```
+
+#### `packages/core/src/server.ts` (824 lines)
+
+**R7** — Dynamic tick interval:
+```typescript
+// Replace fixed setInterval with dynamic:
+const scheduleTick = () => {
+  setTimeout(async () => {
+    await orchestrator.tick()
+    if (!shuttingDown) scheduleTick()
+  }, orchestrator.getTickInterval())
+}
+scheduleTick()
+```
+
+**Decision #8** — TTL check in hourly cleanup:
+```typescript
+// In the hourly cleanup interval:
+const expired = queue.expireWaitingDeviceMessages(ttlMs)
+for (const msg of expired) {
+  emitter.emit('message:expired', { id: msg.id, ... })
+}
+```
+
+### Acceptance Criteria
+- [ ] Message stuck in `sending` for 6 min: recovered to `queued`
+- [ ] Message stuck in `locked` for 3 min: recovered to `queued`
+- [ ] Stale recovery: logged with count and message IDs
+- [ ] Stale recovery: `message_events` row written per message
+- [ ] SIGTERM during active send: waits up to 30s for completion
+- [ ] All senders capped: tick backs off to 60s max
+- [ ] First successful send: tick resets to 5s
+- [ ] Device switch requeue: `message_events` row with `requeue_device_switch`
+- [ ] `interim_failure` callback sent before WAHA fallback
+- [ ] `expired` callback sent when TTL expires
+- [ ] `waiting_device` messages transition to `permanently_failed` after TTL
+- [ ] Tests pass
+
+---
+
+## Batch 9: Test Suite
+
+**Commit**: `test(plugins): E2E flow, route coverage, HMAC verification, edge cases`
+**Findings**: T1-T14
+**Decision**: #38
+
+### Test Files to Create/Modify
+
+#### T1 — E2E Integration Test (HIGHEST PRIORITY)
+**File**: `packages/core/src/plugins/plugin-e2e.test.ts` (NEW)
+
+Test the complete loop with mocked ADB:
+```
+enqueue → dequeueBySender → engine.send (mocked) → message:sent
+→ PluginEventBus → CallbackDelivery → HTTP POST (mocked)
+```
+Verify: callback payload contains all expected fields, HMAC is correct.
+
+#### T2 — Route Coverage
+**File**: `packages/core/src/plugins/oralsin-routes.test.ts` (NEW)
+
+- `POST /contacts/pre-register`: valid payload, invalid payload, ctx=null
+- `GET /status`: returns plugin name, version, events
+- `GET /queue`: returns stats, ctx=null returns 503
+
+#### T3 — HMAC Verification
+**File**: Update `callback-delivery.test.ts`
+
+Verify exact HMAC value:
+```typescript
+const expected = createHmac('sha256', secret).update(body).digest('hex')
+expect(headers['X-Dispatch-Signature']).toBe(expected)
+```
+
+#### T4 — 409 Duplicate at Oralsin Route Layer
+**File**: Update `oralsin-sender-resolution.test.ts`
+```typescript
+it('returns 409 when idempotency key already exists')
+```
+
+#### T5 — Partial Batch (Mixed Resolve/Reject)
+```typescript
+it('partial batch: enqueues resolvable, rejects unresolvable, returns 201 with rejected_details')
+```
+
+#### T6 — `destroyAll` with Multiple Plugins
+**File**: Update `plugin-loader.test.ts`
+```typescript
+it('destroyAll calls destroy on all plugins even if first throws')
+```
+
+#### T7 — `getMessageStatus`
+```typescript
+it('getMessageStatus returns null for unknown id')
+it('getMessageStatus returns PluginMessage shape for known id')
+```
+
+#### T8 — Post-Destroy Dispatch
+**File**: Update `plugin-event-bus.test.ts`
+```typescript
+it('does not dispatch events after destroy()')
+```
+
+#### T9 — Callback 4xx/503 Short-Circuit
+**File**: Update `callback-delivery.test.ts`
+```typescript
+it('stops retrying on 400 after first attempt')
+it('retries on 503 with short backoff [0, 1s, 2s, 4s]')
+it('retries all 4 times on 500')
+```
+
+#### T10 — `getPluginByApiKey` with Disabled Plugin
+**File**: Update `plugin-registry.test.ts`
+```typescript
+it('getPluginByApiKey returns null for disabled plugin')
+```
+
+#### T11 — `updatePlugin` Dual Fields
+```typescript
+it('updatePlugin with both webhookUrl and events simultaneously')
+```
+
+#### T12 — `retryFailedCallback` Failure Path
+```typescript
+it('increments attempts and updates last_error on failed retry')
+```
+
+#### T13/T14 — Timer Fixes
+**File**: Update `plugin-event-bus.test.ts`
+- Use `vi.useFakeTimers()` for timeout test
+- Move `vi.useRealTimers()` to `afterEach`
+
+### Acceptance Criteria
+- [ ] E2E test covers: enqueue → send → callback → HMAC verified
+- [ ] All 3 public Oralsin routes have tests
+- [ ] HMAC value verified cryptographically (not just existence)
+- [ ] 409 tested at route layer
+- [ ] Partial batch tested with mixed resolve/reject
+- [ ] `destroyAll` resilience tested
+- [ ] Post-destroy silence tested
+- [ ] 4xx/503/5xx callback behaviors tested individually
+- [ ] All timer tests use fake timers
+- [ ] Full test suite passes: `pnpm test`
+
+---
+
+## Batch 10: Grafana Dashboards & Documentation
+
+**Commit**: `docs(hardening): dashboards, cross-repo contract, grill decisions`
+**Decisions**: #23, #24
+
+### Files to Create/Modify
+
+#### Grafana Dashboards
+- `monitoring/grafana/dashboards/dispatch-overview.json` — add callback panels, per-plugin depth
+- `monitoring/grafana/dashboards/sender-health.json` — add plugin error panel
+- `monitoring/grafana/dashboards/anti-ban-fingerprint.json` — add dedup miss panel
+
+#### Prometheus Config
+- `monitoring/prometheus/prometheus.yml` — add `authorization` header for `/metrics` scrape:
+```yaml
+scrape_configs:
+  - job_name: 'dispatch'
+    static_configs:
+      - targets: ['host.docker.internal:7890']
+    authorization:
+      type: 'ApiKey'
+      credentials: '${DISPATCH_API_KEY}'
+    metrics_path: '/metrics'
+```
+
+#### Cross-Repo Contract Document
+- `docs/contract-dispatch-oralsin.md` (NEW) — Document:
+  - Enqueue request schema
+  - All 5 callback types: `result`, `ack`, `patient_response`, `interim_failure`, `expired`
+  - Phone format rules
+  - Sender resolution logic
+  - 503/retry semantics
+  - HMAC verification instructions
+  - `fallback_reason` with real error codes
+
+#### Python-Side Changes Document
+- `docs/cross-repo/oralsin-callback-handler-changes.md` (NEW) — Document:
+  - `handle_interim_failure(payload)` — implementation spec
+  - `handle_expired(payload)` — implementation spec
+  - `dispatch_callback_view.py` routing changes
+  - Prometheus metric additions
+
+#### Update `.dev-state/progress.md`
+
+### Acceptance Criteria
+- [ ] All Grafana dashboards load without errors
+- [ ] Prometheus scrapes with API key successfully
+- [ ] Contract document covers all 5 callback types
+- [ ] Python-side changes documented with code examples
+- [ ] `.dev-state/progress.md` updated
+
+---
+
+## Post-Execution Verification
+
+After all 10 batches:
+
+```bash
+# 1. Full test suite
+pnpm test
+
+# 2. Server starts with all env vars
+DISPATCH_PLUGINS=oralsin \
+PLUGIN_ORALSIN_API_KEY=test-key \
+PLUGIN_ORALSIN_HMAC_SECRET=test-secret \
+PLUGIN_ORALSIN_WEBHOOK_URL=https://api.oralsin.debt.com.br/api/v1/webhooks/dispatch/callback/ \
+DISPATCH_WEBHOOK_ALLOWED_DOMAINS=debt.com.br \
+DISPATCH_API_KEY=admin-key \
+pnpm --filter @dispatch/core start
+
+# 3. Server FAILS to start without required vars
+DISPATCH_PLUGINS=oralsin pnpm --filter @dispatch/core start
+# Expected: Error — PLUGIN_ORALSIN_API_KEY required
+
+# 4. Verify schema
+sqlite3 dispatch.db ".schema messages"    # sent_at column, CHECK, FK
+sqlite3 dispatch.db ".schema plugins"     # ISO timestamps
+sqlite3 dispatch.db ".indexes messages"   # idx_messages_plugin_name
+
+# 5. E2E test send (if device available)
+curl -X POST http://localhost:7890/api/v1/plugins/oralsin/enqueue \
+  -H "X-API-Key: test-key" \
+  -H "Content-Type: application/json" \
+  -d '{"idempotency_key":"hardening-test-1","patient":{"phone":"5543991938235","name":"Test"},"message":{"text":"Hardening sprint complete"},"senders":[{"phone":"+554396837945","session":"oralsin_1_4","pair":"oralsin-1-4","role":"primary"}]}'
+```
+
+---
+
+## Cross-Repo Dependency (BLOQUEANTE para deploy)
+
+Before deploying Dispatch with these changes, the Python/Oralsin side must:
+
+1. **Add `handle_interim_failure`** in `DispatchCallbackHandler`
+2. **Add `handle_expired`** in `DispatchCallbackHandler`
+3. **Update `dispatch_callback_view.py`** routing for new event types
+4. **Deploy Python changes first** (Decision #24)
+5. **Then deploy Dispatch**
+
+---
+
+## Summary
+
+| Batch | Scope | Findings | Est. Files |
+|-------|-------|----------|------------|
+| 1 | DB Schema & Config | 10 | 4 |
+| 2 | State Machine & Queue | 9 | 3 |
+| 3 | Plugin Core | 8 | 3 |
+| 4 | Callback System | 7 | 2 |
+| 5 | Oralsin Contract | 7 | 3 |
+| 6 | Server Integration | 14 | 5 |
+| 7 | Observability & Metrics | 7 | 5+ |
+| 8 | Resilience & Recovery | 6 | 4 |
+| 9 | Tests | 14 | 8+ |
+| 10 | Dashboards & Docs | — | 6+ |
+| **Total** | | **82 unique** | |
+
+> 5 findings (Q5=A6 duplicate, DB6/DB7 resolved by decisions, S14 label kept) are resolved within other batches.


### PR DESCRIPTION
## Summary

Hardening sprint covering 87 audit findings across 10 sequential batches with 43 grill decisions. All changes are backwards-compatible (internal contract, Decision #5).

### Batches

| # | Scope | Key Changes |
|---|-------|-------------|
| 1 | DB Schema | busy_timeout=5000, wal_autocheckpoint=400, sent_at column, CHECK priority 1-10, idx_messages_plugin_name, ISO 8601 timestamps |
| 2 | State Machine | `updateStatus(id, from, to)` CAS enforcement, VALID_TRANSITIONS map, partial-failure enqueueBatch, maxRetries fix (D3/P11) |
| 3 | Plugin Core | Init error re-throw + log, safe destroyAll, registry source of truth (no pluginEnabled map), timer leak fix |
| 4 | Callback System | 503 retryable [0,1s,2s,4s], AbortSignal.timeout(10s), response body in last_error, interim_failure + expired types |
| 5 | Oralsin Contract | E.164 phone validation, text max 4096, batch max 500, context max 64KB, phone normalization (Postel's Law), paused sender skip |
| 6 | Server Integration | timingSafeEqual ALL methods, body limit 1MB, path validation, /metrics auth, strip secrets from admin GET, config validation |
| 7 | Observability | 4 new Prometheus metrics (callbacks_total, plugin_errors, queue_depth_by_plugin, waha_dedup_miss), onError wired |
| 8 | Resilience | Sending recovery (>300s), tick backoff 5s→60s cap, TTL expiry for waiting_device |
| 9 | Tests | E2E plugin flow, HMAC crypto verification, 503/400/500 retry coverage, 16 new tests |
| 10 | Docs | Cross-repo contract (5 callback types), Prometheus auth config |

### Stats
- **784 tests passing** (35 new, 0 failures)
- **60 test files**
- **0 new TypeScript errors** (only pre-existing in devices.ts, screenshot-policy.ts)
- **38 files changed**, +3036 / -217 lines

### Cross-repo dependency (BLOCKING for deploy)
Python/Oralsin must deploy `handle_interim_failure` + `handle_expired` **before** this Dispatch version.
See `docs/contract-dispatch-oralsin.md` for full contract.

## Test plan
- [x] Full test suite: 784/784 passing
- [x] TypeScript: 0 new errors
- [x] State machine transitions verified with CAS
- [x] HMAC verified cryptographically (not just existence)
- [x] Partial-failure batch: blacklisted skip, duplicate DO NOTHING
- [x] 503 retry with short backoff verified
- [ ] E2E: plugin enqueue → ADB send → callback (requires device)
- [ ] Deploy Python `interim_failure`/`expired` handlers first

🤖 Generated with [Claude Code](https://claude.com/claude-code)